### PR TITLE
New links are no longer prepended by a wrong base URL.

### DIFF
--- a/Classes/WPEditorView.m
+++ b/Classes/WPEditorView.m
@@ -109,14 +109,15 @@ static NSString* const kDefaultCallbackParameterComponentSeparator = @"=";
 		htmlEditor = [self editorHTML];
 	}];
 	
-	NSBlockOperation* editorDidLoadOperation = [NSBlockOperation blockOperationWithBlock:^{
-		
-		__strong typeof(weakSelf) strongSelf = weakSelf;
-		
-		if (strongSelf) {
-			[strongSelf.webView loadHTMLString:htmlEditor baseURL:nil];
-		}
-	}];
+    NSBlockOperation* editorDidLoadOperation = [NSBlockOperation blockOperationWithBlock:^{
+        __strong typeof(weakSelf) strongSelf = weakSelf;
+
+        if (strongSelf) {
+            NSURL* const kBaseURL = [NSURL URLWithString:@"http://"];
+            
+            [strongSelf.webView loadHTMLString:htmlEditor baseURL:kBaseURL];
+        }
+    }];
 	
 	[loadEditorOperation setCompletionBlock:^{
 		

--- a/Classes/WPEditorViewController.m
+++ b/Classes/WPEditorViewController.m
@@ -1680,11 +1680,11 @@ typedef enum
 			if (buttonIndex == 1) {
 				NSString *linkURL = [alertView textFieldAtIndex:0].text;
 				NSString *linkTitle = [alertView textFieldAtIndex:1].text;
-				
+                
 				if ([linkTitle length] == 0) {
 					linkTitle = linkURL;
 				}
-				
+                
 				if (isInsertingNewLink) {
 					[weakSelf insertLink:linkURL title:linkTitle];
 				} else {


### PR DESCRIPTION
Some links were prepended with a strange URL as reported in [this ticket](https://github.com/wordpress-mobile/WordPress-iOS-Editor/issues/168).  This PR fixes the issue.
