### PR TITLE
Fixes a problem with keypresses.

### DIFF
--- a/Assets/ZSSRichTextEditor.js
+++ b/Assets/ZSSRichTextEditor.js
@@ -74,7 +74,7 @@ zss_editor.init = function() {
 		zss_editor.callback("callback-focus-out");
 	});
 	
-	editor.bind('keyup', function(e) {
+	editor.bind('keypress', function(e) {
 		zss_editor.sendEnabledStyles(e);
 		zss_editor.callback("callback-user-triggered-change");
 	});


### PR DESCRIPTION
Fixes [this bug](https://github.com/wordpress-mobile/WordPress-iOS-Editor/issues/148), which [was previously fixed](https://github.com/wordpress-mobile/WordPress-iOS-Editor/pull/223) in branch `develop` by mistake.

@bummytime - Can you check this out?  Thanks!
