### PR TITLE
When switching back from HTML mode, the content is focused.

### DIFF
--- a/Classes/WPEditorView.m
+++ b/Classes/WPEditorView.m
@@ -999,7 +999,7 @@ shouldStartLoadWithRequest:(NSURLRequest *)request
 	self.sourceView.hidden = YES;
 	self.webView.hidden = NO;
     
-    [self.titleField focus];
+    [self.contentField focus];
 }
 
 #pragma mark - Editing lock


### PR DESCRIPTION
Fixes [this issue](https://github.com/wordpress-mobile/WordPress-iOS-Editor/issues/232).

/cc @jleandroperez
