### PR TITLE
Avoid emptying ZSSField if it has child image nodes.

### DIFF
--- a/Assets/ZSSRichTextEditor.js
+++ b/Assets/ZSSRichTextEditor.js
@@ -847,7 +847,7 @@ ZSSField.prototype.emptyFieldIfNoContents = function() {
     var nbsp = '\xa0';
     var text = this.wrappedObject.text().replace(nbsp, '');
     
-    if (text.length == 0)
+    if (text.length == 0) {
         
         var hasChildImages = (this.wrappedObject.find('img').length > 0);
         


### PR DESCRIPTION
Fixes [this bug](https://github.com/wordpress-mobile/WordPress-iOS-Editor/issues/261).

/cc @bummytime 
