### PR TITLE
Removed the underline button from format bar.

### DIFF
--- a/Classes/WPEditorViewController.m
+++ b/Classes/WPEditorViewController.m
@@ -218,7 +218,6 @@ typedef enum
 	ZSSRichTextEditorToolbar defaultToolbarItems = (ZSSRichTextEditorToolbarInsertImage
 													| ZSSRichTextEditorToolbarBold
 													| ZSSRichTextEditorToolbarItalic
-													| ZSSRichTextEditorToolbarUnderline
 													| ZSSRichTextEditorToolbarInsertLink
 													| ZSSRichTextEditorToolbarBlockQuote
                                                     | ZSSRichTextEditorToolbarUnorderedList


### PR DESCRIPTION
Title has it. Fixes #315.

/cc @diegoreymendez 
