### PR TITLE
Exiting edit mode hides the HTML source view.

### DIFF
--- a/Classes/WPEditorView.m
+++ b/Classes/WPEditorView.m
@@ -1082,6 +1082,10 @@ shouldStartLoadWithRequest:(NSURLRequest *)request
 
 - (void)disableEditing
 {
+    if (!self.sourceView.hidden) {
+        [self showVisualEditor];
+    }
+    
     [self.titleField disableEditing];
     [self.contentField disableEditing];
 }


### PR DESCRIPTION
Fixes [this bug](https://github.com/wordpress-mobile/WordPress-iOS-Editor/issues/128).

/cc @bummytime 
