### PR TITLE
Removes the editor's keyboard observer for some notifications.

### DIFF
--- a/Classes/WPEditorView.m
+++ b/Classes/WPEditorView.m
@@ -206,6 +206,8 @@ static NSString* const kWPEditorViewFieldContentId = @"zss_field_content";
 
 - (void)stopObservingKeyboardNotifications
 {
+    [[NSNotificationCenter defaultCenter] removeObserver:self name:UIKeyboardDidShowNotification object:nil];
+    [[NSNotificationCenter defaultCenter] removeObserver:self name:UIKeyboardDidHideNotification object:nil];
     [[NSNotificationCenter defaultCenter] removeObserver:self name:UIKeyboardWillShowNotification object:nil];
     [[NSNotificationCenter defaultCenter] removeObserver:self name:UIKeyboardWillHideNotification object:nil];
 }


### PR DESCRIPTION
The editor was crashing since it was not removing itself as an observer for some events.

Priority lane for this please! :fast_forward: 

/cc @bummytime 
