### PR TITLE
The placeholder text is now dimmed when focused.

### DIFF
--- a/Assets/editor.html
+++ b/Assets/editor.html
@@ -863,6 +863,11 @@ function style_html(html_source, options) {
     
         div[placeholderText][contenteditable=true]:empty:before {
             content: attr(placeholderText);
+            transition: 0.2s ease opacity;
+        }
+    
+        div[placeholderText][contenteditable=true]:empty:focus:before {
+            opacity: 0.6;
         }
     
         #zss_field_title, #zss_field_title p {


### PR DESCRIPTION
Fixes [this issue](https://github.com/wordpress-mobile/WordPress-iOS-Editor/issues/350).

Courtesy of @thianhlu. :+1:   Works very nicely.

/cc @bummytime 
