### PR TITLE
Images the fail to download still replace the src attribute.

### DIFF
--- a/Assets/ZSSRichTextEditor.js
+++ b/Assets/ZSSRichTextEditor.js
@@ -653,6 +653,16 @@ ZSSEditor.replaceLocalImageWithRemoteImage = function(imageNodeIndentifier, remo
             ZSSEditor.callback("callback-input", joinedArguments);
         }
         
+        image.onerror = function () {
+            // Even on an error, we swap the image for the time being.  This is because private
+            // blogs are currently failing to download images due to access privilege issues.
+            //
+            imageNode.attr('src', image.src);
+            
+            var joinedArguments = ZSSEditor.getJoinedFocusedFieldIdAndCaretArguments();
+            ZSSEditor.callback("callback-input", joinedArguments);
+        }
+        
         image.src = remoteImageUrl;
     }
 };


### PR DESCRIPTION
Fixes [this issue](https://github.com/wordpress-mobile/WordPress-iOS-Editor/issues/365).

Can be tested on WPiOS branch `issue/editor-365-swap-images-on-download-failure`.

More work is needed in this feature, but for the time being this fix is an improvement.

/cc @bummytime 
