### PR TITLE
Added editorShouldDisplaySourceView to the WPEditorViewControllerDelegate

### DIFF
--- a/Classes/WPEditorViewController.h
+++ b/Classes/WPEditorViewController.h
@@ -18,6 +18,7 @@ WPEditorViewControllerMode;
 - (void)editorDidBeginEditing:(WPEditorViewController *)editorController;
 - (void)editorDidEndEditing:(WPEditorViewController *)editorController;
 - (void)editorDidFinishLoadingDOM:(WPEditorViewController*)editorController;
+- (BOOL)editorShouldDisplaySourceView:(WPEditorViewController *)editorController;
 - (void)editorTitleDidChange:(WPEditorViewController *)editorController;
 - (void)editorTextDidChange:(WPEditorViewController *)editorController;
 - (void)editorDidPressMedia:(WPEditorViewController *)editorController;

--- a/Classes/WPEditorViewController.m
+++ b/Classes/WPEditorViewController.m
@@ -1084,7 +1084,12 @@ NSInteger const WPLinkAlertViewTag = 92;
 - (void)editorToolbarView:(WPEditorToolbarView *)editorToolbarView
            showHTMLSource:(UIBarButtonItem *)barButtonItem
 {
-    [self showHTMLSource:barButtonItem];
+    if ([self askOurDelegateShouldDisplaySourceView]) {
+        [self showHTMLSource:barButtonItem];
+    } else {
+        // Deselect the HTML button so it is in the proper state
+        [(UIButton *)barButtonItem setSelected:NO];
+    }
 }
 
 #pragma mark - Editor Interaction
@@ -1642,6 +1647,14 @@ didFailLoadWithError:(NSError *)error
     if ([self.delegate respondsToSelector:@selector(editorDidFinishLoadingDOM:)]) {
         [self.delegate editorDidFinishLoadingDOM:self];
     }
+}
+
+- (BOOL)askOurDelegateShouldDisplaySourceView
+{
+    if ([self.delegate respondsToSelector:@selector(editorShouldDisplaySourceView:)]) {
+        return [self.delegate editorShouldDisplaySourceView:self];
+    }
+    return YES;
 }
 
 @end

--- a/Example/EditorDemo/WPViewController.m
+++ b/Example/EditorDemo/WPViewController.m
@@ -57,6 +57,11 @@
     [self setBodyText:htmlParam];
 }
 
+- (BOOL)editorShouldDisplaySourceView:(WPEditorViewController *)editorController
+{
+    return YES;
+}
+
 - (void)editorDidPressMedia:(WPEditorViewController *)editorController
 {
     DDLogInfo(@"Pressed Media!");


### PR DESCRIPTION
This is part of a fix for https://github.com/wordpress-mobile/WordPress-iOS-Editor/issues/351 - the editor will now ask its delegate if the HTML source view should be displayed or not.

/cc @diegoreymendez 
