### PR TITLE
Fix for bold-italic OpenSans font in web view.

### DIFF
--- a/Assets/editor.html
+++ b/Assets/editor.html
@@ -792,6 +792,32 @@ function style_html(html_source, options) {
 	</script>
 
     <style type="text/css">
+        
+        @font-face {
+            font-family: 'OpenSans';
+            src: local("OpenSans");
+            font-weight: normal;
+            font-style: normal;
+        }
+        @font-face {
+            font-family: 'OpenSans';
+            src: local("OpenSans-Italic");
+            font-weight: normal;
+            font-style: italic;
+        }
+        @font-face {
+            font-family: 'OpenSans';
+            src: local("OpenSans-Bold");
+            font-weight: bold;
+            font-style: normal;
+        }
+        @font-face {
+            font-family: 'OpenSans';
+            src: local("OpenSans-BoldItalic");
+            font-weight: bold;
+            font-style: italic;
+        }
+        
         * {outline: 0px solid transparent;
             -webkit-tap-highlight-color: rgba(0,0,0,0);
             -webkit-touch-callout: none;

--- a/Classes/WPEditorViewController.m
+++ b/Classes/WPEditorViewController.m
@@ -132,9 +132,12 @@ NSInteger const WPLinkAlertViewTag = 92;
     self.didFinishLoadingEditor = NO;
     self.view.backgroundColor = [UIColor whiteColor];
     
-    // Calling this here so the Merriweather font is
-    // loaded (if it has not been already).
+    // Calling the fonts we use here so they are availible to the UIWebView
     [WPFontManager merriweatherBoldFontOfSize:30];
+    [WPFontManager openSansRegularFontOfSize:16];
+    [WPFontManager openSansItalicFontOfSize:16];
+    [WPFontManager openSansBoldFontOfSize:16];
+    [WPFontManager openSansBoldItalicFontOfSize:16];
 	
     [self createToolbarView];
     [self buildTextViews];


### PR DESCRIPTION
Title has it. Fixes #404: 

![slack-imgs com](https://cloud.githubusercontent.com/assets/154014/5147415/0f6e3c8c-717b-11e4-8f9f-6acd744334f6.png)

/cc @diegoreymendez 
