### PR TITLE
Fixes some problems with the UIWebView renderer.

### DIFF
--- a/Classes/WPEditorView.m
+++ b/Classes/WPEditorView.m
@@ -254,16 +254,25 @@ static NSString* const WPEditorViewWebViewContentSizeKey = @"contentSize";
     //
     if (object == self.webView.scrollView) {
         
-        if ([keyPath isEqualToString:WPEditorViewWebViewContentSizeKey]) {
-            NSValue *newValue = change[NSKeyValueChangeNewKey];
+        // WORKAROUND: adding this delay seems to fix the following two issues we had...
+        //
+        //  https://github.com/wordpress-mobile/WordPress-iOS-Editor/issues/430
+        //  https://github.com/wordpress-mobile/WordPress-iOS-Editor/issues/430
+        //
+        //  Props to Matt Bumgardner for recommending this!
+        //
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.001 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+            if ([keyPath isEqualToString:WPEditorViewWebViewContentSizeKey]) {
+                NSValue *newValue = change[NSKeyValueChangeNewKey];
+                
+                CGSize newSize;
+                [newValue getValue:&newSize];
             
-            CGSize newSize;
-            [newValue getValue:&newSize];
-        
-            if (newSize.height != self.lastEditorHeight) {
-                [self refreshVisibleViewportAndContentSize];
+                if (newSize.height != self.lastEditorHeight) {
+                    [self refreshVisibleViewportAndContentSize];
+                }
             }
-        }
+        });
     }
 }
 


### PR DESCRIPTION
Fixes [this issue](https://github.com/wordpress-mobile/WordPress-iOS-Editor/issues/430).
Fixes [this issue](https://github.com/wordpress-mobile/WordPress-iOS-Editor/issues/396).

Props to @bummytime for recommending to try this fix.

/cc @bummytime 
