### PR TITLE
Fix for word breaking issue on the editor's local preview

### DIFF
--- a/Assets/editor.html
+++ b/Assets/editor.html
@@ -844,6 +844,7 @@ function style_html(html_source, options) {
             padding-bottom: 0px;
             overflow-y: auto;
             min-height: 100vh;
+            word-wrap: break-word;
         }
     
         p {


### PR DESCRIPTION
Fix for #571

Added explicit word-wrap CSS property to the editor's body