### PR TITLE
The not-found caret position is now handled with null values.

### DIFF
--- a/Assets/ZSSRichTextEditor.js
+++ b/Assets/ZSSRichTextEditor.js
@@ -13,8 +13,6 @@ var isUsingiOS = true;
 // THe default callback parameter separator
 var defaultCallbackSeparator = '~';
 
-var CaretPositionUnknow = -9999;
-
 // The editor object
 var ZSSEditor = {};
 
@@ -274,8 +272,12 @@ ZSSEditor.getSelectedText = function() {
 ZSSEditor.getCaretArguments = function() {
     var caretInfo = this.getYCaretInfo();
     
-    this.caretArguments[0] = 'yOffset=' + caretInfo.y;
-    this.caretArguments[1] = 'height=' + caretInfo.height;
+    if (caretInfo == null) {
+        this.caretArguments = null;
+    } else {
+        this.caretArguments[0] = 'yOffset=' + caretInfo.y;
+        this.caretArguments[1] = 'height=' + caretInfo.height;
+    }
     
     return this.caretArguments;
 };
@@ -317,16 +319,15 @@ ZSSEditor.getCaretYPosition = function() {
 }
 
 ZSSEditor.getYCaretInfo = function() {
-    var y = 0;
-    var height = 0;
     var selection = window.getSelection();
     var noSelectionAvailable = selection.rangeCount == 0;
+    
     if (noSelectionAvailable) {
-        this.caretInfo.y = CaretPositionUnknow;
-        this.caretInfo.height = CaretPositionUnknow;
-        return this.caretInfo;
+        return null;
     }
     
+    var y = 0;
+    var height = 0;
     var range = selection.getRangeAt(0);
     var needsToWorkAroundNewlineBug = (range.getClientRects().length == 0);
     

--- a/Assets/ZSSRichTextEditor.js
+++ b/Assets/ZSSRichTextEditor.js
@@ -273,13 +273,12 @@ ZSSEditor.getCaretArguments = function() {
     var caretInfo = this.getYCaretInfo();
     
     if (caretInfo == null) {
-        this.caretArguments = null;
+        return null;
     } else {
         this.caretArguments[0] = 'yOffset=' + caretInfo.y;
         this.caretArguments[1] = 'height=' + caretInfo.height;
+        return this.caretArguments;
     }
-    
-    return this.caretArguments;
 };
 
 ZSSEditor.getJoinedFocusedFieldIdAndCaretArguments = function() {

--- a/Classes/WPEditorView.m
+++ b/Classes/WPEditorView.m
@@ -30,8 +30,8 @@ static NSString* const WPEditorViewWebViewContentSizeKey = @"contentSize";
 @interface WPEditorView () <UITextViewDelegate, UIWebViewDelegate, UITextFieldDelegate>
 
 #pragma mark - Cached caret & line data
-@property (nonatomic, copy, readwrite) NSNumber *caretYOffset;
-@property (nonatomic, copy, readwrite) NSNumber *lineHeight;
+@property (nonatomic, strong, readwrite) NSNumber *caretYOffset;
+@property (nonatomic, strong, readwrite) NSNumber *lineHeight;
 
 #pragma mark - Editor height
 @property (nonatomic, assign, readwrite) NSInteger lastEditorHeight;

--- a/Classes/WPEditorView.m
+++ b/Classes/WPEditorView.m
@@ -1174,7 +1174,9 @@ shouldStartLoadWithRequest:(NSURLRequest *)request
  */
 - (void)scrollToCaretAnimated:(BOOL)animated
 {
-    if (self.caretYOffset == nil && self.lineHeight == nil) {
+    BOOL notEnoughInfoToScroll = self.caretYOffset == nil || self.lineHeight == nil;
+    
+    if (notEnoughInfoToScroll) {
         return;
     }
     

--- a/Classes/WPEditorView.m
+++ b/Classes/WPEditorView.m
@@ -27,13 +27,11 @@ static const CGFloat iPadHTMLViewLeftRightInset = 85.0f;
 
 static NSString* const WPEditorViewWebViewContentSizeKey = @"contentSize";
 
-static NSInteger CaretPositionUnknow = -9999;
-
 @interface WPEditorView () <UITextViewDelegate, UIWebViewDelegate, UITextFieldDelegate>
 
 #pragma mark - Cached caret & line data
-@property (nonatomic, assign, readwrite) CGFloat caretYOffset;
-@property (nonatomic, assign, readwrite) CGFloat lineHeight;
+@property (nonatomic, copy, readwrite) NSNumber *caretYOffset;
+@property (nonatomic, copy, readwrite) NSNumber *lineHeight;
 
 #pragma mark - Editor height
 @property (nonatomic, assign, readwrite) NSInteger lastEditorHeight;
@@ -614,6 +612,9 @@ shouldStartLoadWithRequest:(NSURLRequest *)request
     static NSString* const kYOffsetParameterName = @"yOffset";
     static NSString* const kLineHeightParameterName = @"height";
     
+    self.caretYOffset = nil;
+    self.lineHeight = nil;
+    
     [self parseParametersFromCallbackURL:url
          andExecuteBlockForEachParameter:^(NSString *parameterName, NSString *parameterValue)
      {
@@ -627,10 +628,10 @@ shouldStartLoadWithRequest:(NSURLRequest *)request
              self.webView.customInputAccessoryView = self.focusedField.inputAccessoryView;
          } else if ([parameterName isEqualToString:kYOffsetParameterName]) {
              
-             self.caretYOffset = [parameterValue floatValue];
+             self.caretYOffset = @([parameterValue floatValue]);
          } else if ([parameterName isEqualToString:kLineHeightParameterName]) {
              
-             self.lineHeight = [parameterValue floatValue];
+             self.lineHeight = @([parameterValue floatValue]);
          }
      } onComplete:^() {
          
@@ -799,15 +800,18 @@ shouldStartLoadWithRequest:(NSURLRequest *)request
     static NSString* const kYOffsetParameterName = @"yOffset";
     static NSString* const kLineHeightParameterName = @"height";
     
+    self.caretYOffset = nil;
+    self.lineHeight = nil;
+    
     [self parseParametersFromCallbackURL:url
          andExecuteBlockForEachParameter:^(NSString *parameterName, NSString *parameterValue)
      {
          if ([parameterName isEqualToString:kYOffsetParameterName]) {
              
-             self.caretYOffset = [parameterValue floatValue];
+             self.caretYOffset = @([parameterValue floatValue]);
          } else if ([parameterName isEqualToString:kLineHeightParameterName]) {
              
-             self.lineHeight = [parameterValue floatValue];
+             self.lineHeight = @([parameterValue floatValue]);
          }
      } onComplete:^() {
          [self scrollToCaretAnimated:NO];
@@ -1166,18 +1170,17 @@ shouldStartLoadWithRequest:(NSURLRequest *)request
 
 /**
  *  @brief      Scrolls to a position where the caret is visible. This uses the values stored in caretYOffest and lineHeight properties.
- *  @discussion If the values of both properties  match CaretPositionUnknow no scrolling happens.
  *  @param      animated    If the scrolling shoud be animated  The offset to show.
  */
 - (void)scrollToCaretAnimated:(BOOL)animated
 {
-    if (self.caretYOffset == CaretPositionUnknow
-        && self.lineHeight == CaretPositionUnknow) {
+    if (self.caretYOffset == nil && self.lineHeight == nil) {
         return;
     }
+    
     CGRect viewport = [self viewport];
-    CGFloat caretYOffset = self.caretYOffset;
-    CGFloat lineHeight = self.lineHeight;
+    CGFloat caretYOffset = [self.caretYOffset floatValue];
+    CGFloat lineHeight = [self.lineHeight floatValue];
     CGFloat offsetBottom = caretYOffset + lineHeight;
     
     BOOL mustScroll = (caretYOffset < viewport.origin.y


### PR DESCRIPTION
Fixes [this issue](https://github.com/wordpress-mobile/WordPress-Editor-iOS/issues/529).

Can I bother you with a review @aerych?

<!---
@huboard:{"order":510.9999961927533,"milestone_order":583,"custom_state":""}
-->
