### PR TITLE
IME keyboard fixes

### DIFF
--- a/Assets/ZSSRichTextEditor.js
+++ b/Assets/ZSSRichTextEditor.js
@@ -1654,6 +1654,10 @@ ZSSEditor.parentTags = function() {
 // MARK: - ZSSField Constructor
 
 function ZSSField(wrappedObject) {
+    // When this bool is true, we are going to restrict input and certain callbacks
+    // so IME keyboards behave properly when composing.
+    this.isComposing = false;
+    
     this.multiline = false;
     this.wrappedObject = wrappedObject;
     this.bodyPlaceholderColor = '#000000';
@@ -1676,6 +1680,8 @@ ZSSField.prototype.bindListeners = function() {
     this.wrappedObject.bind('blur', function(e) { thisObj.handleBlurEvent(e); });
     this.wrappedObject.bind('keydown', function(e) { thisObj.handleKeyDownEvent(e); });
     this.wrappedObject.bind('input', function(e) { thisObj.handleInputEvent(e); });
+    this.wrappedObject.bind('compositionstart', function(e) { thisObj.handleCompositionStartEvent(e); });
+    this.wrappedObject.bind('compositionend', function(e) { thisObj.handleCompositionEndEvent(e); });
 };
 
 // MARK: - Emptying the field when it should be, well... empty (HTML madness)
@@ -1728,33 +1734,42 @@ ZSSField.prototype.handleFocusEvent = function(e) {
 };
 
 ZSSField.prototype.handleKeyDownEvent = function(e) {
-    
+
     var wasEnterPressed = (e.keyCode == '13');
     
-    if(wasEnterPressed) {
+    if (this.isComposing) {
+        e.stopPropagation();
+    } else if (wasEnterPressed) {
         ZSSEditor.formatNewLine(e);
-    } else {
+    } else if (ZSSEditor.closerParentNode() == this.wrappedDomNode()) {
         // IMPORTANT: without this code, we can have text written outside of paragraphs...
         //
-        if (ZSSEditor.closerParentNode() == this.wrappedDomNode()) {
-            document.execCommand('formatBlock', false, 'p');
-        }
+        document.execCommand('formatBlock', false, 'p');
     }
 };
 
 ZSSField.prototype.handleInputEvent = function(e) {
-    
-    // IMPORTANT: we want the placeholder to come up if there's no text, so we clear the field if
-    // there's no real content in it.  It's important to do this here and not on keyDown or keyUp
-    // as the field could become empty because of a cut or paste operation as well as a key press.
-    // This event takes care of all cases.
-    //
-    this.emptyFieldIfNoContentsAndRefreshPlaceholderColor();
-    
-    var joinedArguments = ZSSEditor.getJoinedFocusedFieldIdAndCaretArguments();
+    if (!this.isComposing) {
+        // IMPORTANT: we want the placeholder to come up if there's no text, so we clear the field if
+        // there's no real content in it.  It's important to do this here and not on keyDown or keyUp
+        // as the field could become empty because of a cut or paste operation as well as a key press.
+        // This event takes care of all cases.
+        //
+        this.emptyFieldIfNoContentsAndRefreshPlaceholderColor();
+        
+        var joinedArguments = ZSSEditor.getJoinedFocusedFieldIdAndCaretArguments();
 
-    ZSSEditor.callback('callback-selection-changed', joinedArguments);
-    this.callback("callback-input", joinedArguments);
+        ZSSEditor.callback('callback-selection-changed', joinedArguments);
+        this.callback("callback-input", joinedArguments);
+    }
+};
+
+ZSSField.prototype.handleCompositionStartEvent = function(e) {
+    this.isComposing = true;
+};
+
+ZSSField.prototype.handleCompositionEndEvent = function(e) {
+    this.isComposing = false;
 };
 
 ZSSField.prototype.handleTapEvent = function(e) {

--- a/Assets/ZSSRichTextEditor.js
+++ b/Assets/ZSSRichTextEditor.js
@@ -1749,19 +1749,20 @@ ZSSField.prototype.handleKeyDownEvent = function(e) {
 };
 
 ZSSField.prototype.handleInputEvent = function(e) {
-    if (!this.isComposing) {
-        // IMPORTANT: we want the placeholder to come up if there's no text, so we clear the field if
-        // there's no real content in it.  It's important to do this here and not on keyDown or keyUp
-        // as the field could become empty because of a cut or paste operation as well as a key press.
-        // This event takes care of all cases.
-        //
-        this.emptyFieldIfNoContentsAndRefreshPlaceholderColor();
-        
-        var joinedArguments = ZSSEditor.getJoinedFocusedFieldIdAndCaretArguments();
+    
+    // Skip this if we are composing on an IME keyboard
+    if (this.isComposing ) { return; }
 
-        ZSSEditor.callback('callback-selection-changed', joinedArguments);
-        this.callback("callback-input", joinedArguments);
-    }
+    // IMPORTANT: we want the placeholder to come up if there's no text, so we clear the field if
+    // there's no real content in it.  It's important to do this here and not on keyDown or keyUp
+    // as the field could become empty because of a cut or paste operation as well as a key press.
+    // This event takes care of all cases.
+    //
+    this.emptyFieldIfNoContentsAndRefreshPlaceholderColor();
+    
+    var joinedArguments = ZSSEditor.getJoinedFocusedFieldIdAndCaretArguments();
+    ZSSEditor.callback('callback-selection-changed', joinedArguments);
+    this.callback("callback-input", joinedArguments);
 };
 
 ZSSField.prototype.handleCompositionStartEvent = function(e) {


### PR DESCRIPTION
Fix for #590. This fix should prevent any duplicate letters appearing with IME keyboards and also restrict the number of input callbacks while composing (there were a TON previously).

To test this fix, enable the Japanese - Romaji keyboard and then run the Editor demo app. Type "tesuto" into the Romaji keybard and it should NOT be prefixed with the letter "t". Bonus points for trying more words. Non-IME keyboards should work the same as before, but it doesn't hurt to test that too.

**Before:**
![screen shot 2015-03-05 at 12 16 19 pm](https://cloud.githubusercontent.com/assets/154014/6511313/a07d99f4-c331-11e4-9222-9705f39b940d.png)

**After:** 
![screen shot 2015-03-05 at 12 16 33 pm](https://cloud.githubusercontent.com/assets/154014/6511318/a582ceec-c331-11e4-9797-fbc15d9aca81.png)

/cc @aerych if you wouldn't mind