### PR TITLE
Change events order.

### DIFF
--- a/Assets/ZSSRichTextEditor.js
+++ b/Assets/ZSSRichTextEditor.js
@@ -1045,7 +1045,8 @@ ZSSEditor.setProgressOnVideo = function(videoNodeIdentifier, progress) {
  *
  *  @param      VideoNodeIdentifier     The unique Video ID for the uploaded Video
  */
-ZSSEditor.markVideoUploadDone = function(videoNodeIdentifier) {    
+ZSSEditor.markVideoUploadDone = function(videoNodeIdentifier) {
+    this.sendVideoReplacedCallback(videoNodeIdentifier);
     var videoNode = this.getVideoNodeWithIdentifier(videoNodeIdentifier);
     if (videoNode.length > 0) {
         
@@ -1063,7 +1064,6 @@ ZSSEditor.markVideoUploadDone = function(videoNodeIdentifier) {
     }
     var joinedArguments = ZSSEditor.getJoinedFocusedFieldIdAndCaretArguments();
     ZSSEditor.callback("callback-input", joinedArguments);
-    this.sendVideoReplacedCallback(videoNodeIdentifier);
 };
 
 /**

--- a/Assets/ZSSRichTextEditor.js
+++ b/Assets/ZSSRichTextEditor.js
@@ -1046,7 +1046,6 @@ ZSSEditor.setProgressOnVideo = function(videoNodeIdentifier, progress) {
  *  @param      VideoNodeIdentifier     The unique Video ID for the uploaded Video
  */
 ZSSEditor.markVideoUploadDone = function(videoNodeIdentifier) {
-    this.sendVideoReplacedCallback(videoNodeIdentifier);
     var videoNode = this.getVideoNodeWithIdentifier(videoNodeIdentifier);
     if (videoNode.length > 0) {
         
@@ -1064,6 +1063,8 @@ ZSSEditor.markVideoUploadDone = function(videoNodeIdentifier) {
     }
     var joinedArguments = ZSSEditor.getJoinedFocusedFieldIdAndCaretArguments();
     ZSSEditor.callback("callback-input", joinedArguments);
+    var thisObj = this;
+    setTimeout(function() { thisObj.sendVideoReplacedCallback(videoNodeIdentifier);}, 500);
 };
 
 /**

--- a/Assets/ZSSRichTextEditor.js
+++ b/Assets/ZSSRichTextEditor.js
@@ -1063,6 +1063,8 @@ ZSSEditor.markVideoUploadDone = function(videoNodeIdentifier) {
     }
     var joinedArguments = ZSSEditor.getJoinedFocusedFieldIdAndCaretArguments();
     ZSSEditor.callback("callback-input", joinedArguments);
+    // We invoke the sendVideoReplacedCallback with a delay to avoid for
+    // it to be ignored by the webview because of the previous callback being done.
     var thisObj = this;
     setTimeout(function() { thisObj.sendVideoReplacedCallback(videoNodeIdentifier);}, 500);
 };


### PR DESCRIPTION
Fix for #625 

It looks that the video replaced event needs to be send before the input changed event or else it gets lost on the webview.

cc @bummytime 

<!---
@huboard:{"order":546.0,"milestone_order":626,"custom_state":""}
-->
