### PR TITLE
Allows pasted text to be saved

### DIFF
--- a/Assets/ZSSRichTextEditor.js
+++ b/Assets/ZSSRichTextEditor.js
@@ -90,6 +90,13 @@ ZSSEditor.init = function() {
 			}
 		}
 	}, false);
+    
+    $('[contenteditable]').on('paste',function(e) {
+        // Ensure we only insert plaintext from the pasteboard
+        e.preventDefault();
+        var plainText = (e.originalEvent || e).clipboardData.getData('text/plain');
+        document.execCommand('insertText', false, plainText);
+    });
 
 }; //end
 


### PR DESCRIPTION
Fixes #603. The user should now be able to paste text copied from other iOS apps. This is not a magic bullet, but it does help. Any text pasted will lose its formatting and all graphics will be removed.

**How to test:**
1a. Open Mobile Safari, find a web page that has text and graphics.
--or--
1b. Start a new note in Notes.app.

2. Select text (and graphics). Be sure to select different styles if available.

3. Open WPiOS and paste text into new/existing post.

4. Save post.

5. Re-open post and make sure text is still there.

WPiOS branch to test this fix: https://github.com/wordpress-mobile/WordPress-iOS/tree/issue/editor-603-paste-text-fail

/cc @diegoreymendez 

<!---
@huboard:{"order":547.0,"milestone_order":637,"custom_state":""}
-->
