### PR TITLE
Detect media removal on the editor by the user.

### DIFF
--- a/Assets/ZSSRichTextEditor.js
+++ b/Assets/ZSSRichTextEditor.js
@@ -2023,28 +2023,30 @@ ZSSField.prototype.bindListeners = function() {
     this.wrappedObject.bind('input', function(e) { thisObj.handleInputEvent(e); });
     this.wrappedObject.bind('compositionstart', function(e) { thisObj.handleCompositionStartEvent(e); });
     this.wrappedObject.bind('compositionend', function(e) { thisObj.handleCompositionEndEvent(e); });
-    
+    this.bindMutationObserver();
+};
+
+ZSSField.prototype.bindMutationObserver = function () {
     var target = this.wrappedObject[0];
     // create an observer instance
     var observer = new MutationObserver(function(mutations) {
-        mutations.forEach(function(mutation) {
-            for (var i = 0; i < mutation.removedNodes.length; i++) {
-                var removedNode = mutation.removedNodes[i];
-                if ( ZSSEditor.isMediaContainerNode(removedNode) ) {
-                    var mediaIdentifier = ZSSEditor.extractMediaIdentifier(removedNode);
-                    ZSSEditor.sendMediaRemovedCallback(mediaIdentifier);                    
-                }
-            }
-        });
-    });
+                                        mutations.forEach(function(mutation) {
+                                                          for (var i = 0; i < mutation.removedNodes.length; i++) {
+                                                          var removedNode = mutation.removedNodes[i];
+                                                          if ( ZSSEditor.isMediaContainerNode(removedNode) ) {
+                                                          var mediaIdentifier = ZSSEditor.extractMediaIdentifier(removedNode);
+                                                          ZSSEditor.sendMediaRemovedCallback(mediaIdentifier);
+                                                          }
+                                                          }
+                                                          });
+                                        });
     
     // configuration of the observer:
     var config = { attributes: false, childList: true, characterData: false };
     
     // pass in the target node, as well as the observer options
     observer.observe(target, config);
-    
-};
+}
 
 // MARK: - Emptying the field when it should be, well... empty (HTML madness)
 

--- a/Assets/ZSSRichTextEditor.js
+++ b/Assets/ZSSRichTextEditor.js
@@ -764,7 +764,6 @@ ZSSEditor.replaceLocalImageWithRemoteImage = function(imageNodeIdentifier, remot
         ZSSEditor.markImageUploadDone(imageNodeIdentifier);
         var joinedArguments = ZSSEditor.getJoinedFocusedFieldIdAndCaretArguments();
         ZSSEditor.callback("callback-input", joinedArguments);
-        
     }
     
     image.src = remoteImageUrl;
@@ -919,11 +918,9 @@ ZSSEditor.removeImage = function(imageNodeIdentifier) {
  *
  *  @param      mediaNodeIdentifier     The unique media ID
  */
-ZSSEditor.sendMediaRemovedCallback = function( mediaNodeIdentifier ) {
-    var arguments = ['id=' + encodeURIComponent( mediaNodeIdentifier )];
-    
-    var joinedArguments = arguments.join( defaultCallbackSeparator );
-    
+ZSSEditor.sendMediaRemovedCallback = function(mediaNodeIdentifier) {
+    var arguments = ['id=' + encodeURIComponent(mediaNodeIdentifier)];
+    var joinedArguments = arguments.join(defaultCallbackSeparator);
     this.callback("callback-media-removed", joinedArguments);
 };
 

--- a/Assets/ZSSRichTextEditor.js
+++ b/Assets/ZSSRichTextEditor.js
@@ -710,6 +710,23 @@ ZSSEditor.getImageContainerNodeWithIdentifier = function(imageNodeIdentifier) {
     return $('#'+this.getImageContainerIdentifier(imageNodeIdentifier));
 };
 
+ZSSEditor.isMediaContainerNode = function(node) {
+    if (node.id === undefined) {
+        return false;
+    }
+    return (node.id.search("img_container_") == 0) || (node.id.search("video_container_") == 0);
+};
+
+ZSSEditor.extractMediaIdentifier = function(node) {
+    if (node.id.search("img_container_") == 0) {
+        return node.id.replace("img_container_", "");
+    }
+    
+    if (node.id.search("video_container_") == 0) {
+        return node.id.replace("video_container_", "");
+    }
+    return "";
+};
 
 /**
  *  @brief      Replaces a local image URL with a remote image URL.  Useful for images that have
@@ -800,6 +817,8 @@ ZSSEditor.markImageUploadDone = function(imageNodeIdentifier) {
     
     // Remove all extra formatting nodes for progress
     if (imageNode.parent().attr("id") == this.getImageContainerIdentifier(imageNodeIdentifier)) {
+        // remove id from container to avoid to report a user removal
+        imageNode.parent().attr("id", "");
         imageNode.parent().replaceWith(imageNode);
     }
     // Wrap link around image
@@ -888,12 +907,26 @@ ZSSEditor.removeImage = function(imageNodeIdentifier) {
     if (imageNode.length != 0){
         imageNode.remove();
     }
-
     // if image is inside options container we need to remove the container
     var imageContainerNode = this.getImageContainerNodeWithIdentifier(imageNodeIdentifier);
     if (imageContainerNode.length != 0){
+        //reset id before removal to avoid detection of user removal
+        imageContainerNode.attr("id","");
         imageContainerNode.remove();
     }
+};
+
+/**
+ *  @brief      Callbacks to native that the media container was deleted by the user
+ *
+ *  @param      mediaNodeIdentifier     The unique media ID
+ */
+ZSSEditor.sendMediaRemovedCallback = function( mediaNodeIdentifier ) {
+    var arguments = ['id=' + encodeURIComponent( mediaNodeIdentifier )];
+    
+    var joinedArguments = arguments.join( defaultCallbackSeparator );
+    
+    this.callback("callback-media-removed", joinedArguments);
 };
 
 /**
@@ -1032,6 +1065,8 @@ ZSSEditor.markVideoUploadDone = function(videoNodeIdentifier) {
         
         // Remove all extra formatting nodes for progress
         if (videoNode.parent().attr("id") == this.getVideoContainerIdentifier(videoNodeIdentifier)) {
+            // remove id from container to avoid to report a user removal
+            videoNode.parent().attr("id", "");
             videoNode.parent().replaceWith(videoNode);
         }
     }
@@ -1158,6 +1193,8 @@ ZSSEditor.removeVideo = function(videoNodeIdentifier) {
     // if Video is inside options container we need to remove the container
     var videoContainerNode = this.getVideoContainerNodeWithIdentifier(videoNodeIdentifier);
     if (videoContainerNode.length != 0){
+        //reset id before removal to avoid detection of user removal
+        videoContainerNode.attr("id","");
         videoContainerNode.remove();
     }
 };
@@ -1991,6 +2028,27 @@ ZSSField.prototype.bindListeners = function() {
     this.wrappedObject.bind('input', function(e) { thisObj.handleInputEvent(e); });
     this.wrappedObject.bind('compositionstart', function(e) { thisObj.handleCompositionStartEvent(e); });
     this.wrappedObject.bind('compositionend', function(e) { thisObj.handleCompositionEndEvent(e); });
+    
+    var target = this.wrappedObject[0];
+    // create an observer instance
+    var observer = new MutationObserver(function(mutations) {
+        mutations.forEach(function(mutation) {
+            for (var i = 0; i < mutation.removedNodes.length; i++) {
+                var removedNode = mutation.removedNodes[i];
+                if ( ZSSEditor.isMediaContainerNode(removedNode) ) {
+                    var mediaIdentifier = ZSSEditor.extractMediaIdentifier(removedNode);
+                    ZSSEditor.sendMediaRemovedCallback(mediaIdentifier);                    
+                }
+            }
+        });
+    });
+    
+    // configuration of the observer:
+    var config = { attributes: false, childList: true, characterData: false };
+    
+    // pass in the target node, as well as the observer options
+    observer.observe(target, config);
+    
 };
 
 // MARK: - Emptying the field when it should be, well... empty (HTML madness)
@@ -2171,7 +2229,7 @@ ZSSField.prototype.sendImageTappedCallback = function( imageNode ) {
 
     // WORKAROUND: force the event to become sort of "after-tap" through setTimeout()
     //
-    setTimeout(function() { thisObj.callback('callback-image-tap', joinedArguments);}, 500);
+    setTimeout(function() { ZSSEditor.callback('callback-image-tap', joinedArguments);}, 500);
 }
 
 ZSSField.prototype.sendVideoTappedCallback = function( videoNode ) {
@@ -2184,7 +2242,7 @@ ZSSField.prototype.sendVideoTappedCallback = function( videoNode ) {
     
     var joinedArguments = arguments.join( defaultCallbackSeparator );
     
-    this.callback('callback-video-tap', joinedArguments);
+    ZSSEditor.callback('callback-video-tap', joinedArguments);
 }
 
 /**

--- a/Assets/ZSSRichTextEditor.js
+++ b/Assets/ZSSRichTextEditor.js
@@ -720,9 +720,7 @@ ZSSEditor.isMediaContainerNode = function(node) {
 ZSSEditor.extractMediaIdentifier = function(node) {
     if (node.id.search("img_container_") == 0) {
         return node.id.replace("img_container_", "");
-    }
-    
-    if (node.id.search("video_container_") == 0) {
+    } else if (node.id.search("video_container_") == 0) {
         return node.id.replace("video_container_", "");
     }
     return "";

--- a/Classes/WPEditorView.h
+++ b/Classes/WPEditorView.h
@@ -163,6 +163,15 @@ stylesForCurrentSelection:(NSArray*)styles;
  */
 - (void)editorView:(WPEditorView *)editorView videoPressInfoRequest:(NSString *)videoPressID;
 
+/**
+ * @brief		Received when a the editor detects the removal by the user of a uploading media element.
+ *
+ * @param		editorView	 The editor view.
+ * @param		mediaID The media ID that was removed from the editor
+ *
+ */
+- (void)editorView:(WPEditorView *)editorView mediaRemoved:(NSString *)mediaID;
+
 @end
 
 @interface WPEditorView : UIView

--- a/Classes/WPEditorView.m
+++ b/Classes/WPEditorView.m
@@ -499,6 +499,9 @@ shouldStartLoadWithRequest:(NSURLRequest *)request
         } else if ([self isVideoPressInfoRequestScheme:scheme]) {
             [self handleVideoPressInfoRequestCallback:url];
             handled = YES;
+        } else if ([self isMediaRemovedScheme:scheme]) {
+            [self handleMediaRemovedCallback:url];
+            handled = YES;
         }
         
     }
@@ -823,6 +826,27 @@ shouldStartLoadWithRequest:(NSURLRequest *)request
 
 }
 
+- (void)handleMediaRemovedCallback:(NSURL *)url
+{
+    NSParameterAssert([url isKindOfClass:[NSURL class]]);
+    
+    static NSString *const kMediaIdParameterName = @"id";
+    
+    __block NSString *mediaId = nil;
+    
+    [self parseParametersFromCallbackURL:url andExecuteBlockForEachParameter:^(NSString *parameterName, NSString *parameterValue)
+     {
+         if ([parameterName isEqualToString:kMediaIdParameterName]) {
+             mediaId = [self stringByDecodingURLFormat:parameterValue];
+         }
+     } onComplete:^{
+         if ([self.delegate respondsToSelector:@selector(editorView:mediaRemoved:)]) {
+             [self.delegate editorView:self mediaRemoved:mediaId];
+         }
+     }];
+    
+}
+
 /**
  *	@brief		Handles a log callback.
  *
@@ -1085,6 +1109,16 @@ shouldStartLoadWithRequest:(NSURLRequest *)request
              @"We're expecting a non-nil string object here.");
     
     static NSString *const kCallbackScheme = @"callback-videopress-info-request";
+    
+    return [scheme isEqualToString:kCallbackScheme];
+}
+
+- (BOOL)isMediaRemovedScheme:(NSString *)scheme
+{
+    NSAssert([scheme isKindOfClass:[NSString class]],
+             @"We're expecting a non-nil string object here.");
+    
+    static NSString *const kCallbackScheme = @"callback-media-removed";
     
     return [scheme isEqualToString:kCallbackScheme];
 }

--- a/Classes/WPEditorViewController.h
+++ b/Classes/WPEditorViewController.h
@@ -100,6 +100,15 @@ WPEditorViewControllerMode;
 - (void)editorViewController:(WPEditorViewController *)editorViewController
        videoPressInfoRequest:(NSString *)videoID;
 
+/**
+ *	@brief		Received when the editor removed an uploading media.
+ *
+ *	@param		editorView	The editor view.
+ *	@param		mediaID		The id of the media that was removed.
+ */
+- (void)editorViewController:(WPEditorViewController *)editorViewController
+       mediaRemoved:(NSString *)mediaID;
+
 @end
 
 @class ZSSBarButtonItem;

--- a/Classes/WPEditorViewController.h
+++ b/Classes/WPEditorViewController.h
@@ -107,7 +107,7 @@ WPEditorViewControllerMode;
  *	@param		mediaID		The id of the media that was removed.
  */
 - (void)editorViewController:(WPEditorViewController *)editorViewController
-       mediaRemoved:(NSString *)mediaID;
+                mediaRemoved:(NSString *)mediaID;
 
 @end
 

--- a/Classes/WPEditorViewController.m
+++ b/Classes/WPEditorViewController.m
@@ -1681,6 +1681,13 @@ NSInteger const WPLinkAlertViewTag = 92;
 
 }
 
+- (void)editorView:(WPEditorView *)editorView mediaRemoved:(NSString *)mediaID
+{
+    if ([self.delegate respondsToSelector:@selector(editorViewController:mediaRemoved:)]) {
+        [self.delegate editorViewController:self mediaRemoved:mediaID];
+    }
+    
+}
 
 - (void)editorView:(WPEditorView*)editorView stylesForCurrentSelection:(NSArray*)styles
 {

--- a/Example/EditorDemo/WPViewController.m
+++ b/Example/EditorDemo/WPViewController.m
@@ -146,6 +146,12 @@ typedef NS_ENUM(NSUInteger,  WPViewControllerActionSheet) {
     }
 }
 
+- (void)editorViewController:(WPEditorViewController *)editorViewController mediaRemoved:(NSString *)mediaID
+{
+    NSProgress * progress = self.mediaAdded[mediaID];
+    [progress cancel];
+}
+
 #pragma mark - Media actions
 
 - (void)showImageDetailsForImageMeta:(WPImageMeta *)imageMeta
@@ -220,11 +226,14 @@ typedef NS_ENUM(NSUInteger,  WPViewControllerActionSheet) {
                                                                               @"url": path }];
     progress.cancellable = YES;
     progress.totalUnitCount = 100;
-    [NSTimer scheduledTimerWithTimeInterval:0.1
+    NSTimer * timer = [NSTimer scheduledTimerWithTimeInterval:0.1
                                      target:self
                                    selector:@selector(timerFireMethod:)
                                    userInfo:progress
                                     repeats:YES];
+    [progress setCancellationHandler:^{
+        [timer invalidate];
+    }];
     self.mediaAdded[imageID] = progress;
 }
 


### PR DESCRIPTION
Closes #643 

How to test:

Add images or videos to the editor and then remove it by using backspace. 

Check if the - (void)editorViewController:(WPEditorViewController *)editorViewController mediaRemoved:(NSString *)mediaID

callback method is being called on the WPViewController class on the EditorDemo project.

This will need a follow up PR on the WordPress main project to 

@diegoreymendez and @bummytime can you guys have a look on this?