### PR TITLE
Removes some header comments and warnings.

### DIFF
--- a/Classes/CYRTextView.m
+++ b/Classes/CYRTextView.m
@@ -40,6 +40,12 @@
 
 #define RGB(r,g,b) [UIColor colorWithRed:r/255.0f green:g/255.0f blue:b/255.0f alpha:1.0f]
 
+#ifdef CGFLOAT_IS_DOUBLE
+#define CYRAbs fabs
+#else
+#define CYRAbs fabsf
+#endif
+
 static void *CYRTextViewContext = &CYRTextViewContext;
 static const float kCursorVelocity = 1.0f/8.0f;
 
@@ -246,7 +252,7 @@ static const float kCursorVelocity = 1.0f/8.0f;
     if (gestureRecognizer == _singleFingerPanRecognizer || gestureRecognizer == _doubleFingerPanRecognizer)
     {
         CGPoint translation = [gestureRecognizer translationInView:self];
-        return fabsf(translation.x) > fabsf(translation.y);
+        return CYRAbs(translation.x) > CYRAbs(translation.y);
     }
     
     return YES;
@@ -278,11 +284,11 @@ static const float kCursorVelocity = 1.0f/8.0f;
     
     if (cursorLocation > startRange.location)
     {
-        self.selectedRange = NSMakeRange(startRange.location, fabsf(startRange.location - cursorLocation));
+        self.selectedRange = NSMakeRange(startRange.location, CYRAbs(startRange.location - cursorLocation));
     }
     else
     {
-        self.selectedRange = NSMakeRange(cursorLocation, fabsf(startRange.location - cursorLocation));
+        self.selectedRange = NSMakeRange(cursorLocation, CYRAbs(startRange.location - cursorLocation));
     }
 }
 

--- a/Classes/WPEditorLoggingConfiguration.h
+++ b/Classes/WPEditorLoggingConfiguration.h
@@ -5,4 +5,4 @@
 #endif
 #define LOG_LEVEL_DEF kEditorLogLevel
 
-extern const int kEditorLogLevel;
+extern const DDLogLevel kEditorLogLevel;

--- a/Classes/WPEditorLoggingConfiguration.m
+++ b/Classes/WPEditorLoggingConfiguration.m
@@ -1,3 +1,3 @@
 #import "WPEditorLoggingConfiguration.h"
 
-const int kEditorLogLevel = DDLogLevelError;
+const DDLogLevel kEditorLogLevel = DDLogLevelError;

--- a/Classes/WPEditorLoggingConfiguration.m
+++ b/Classes/WPEditorLoggingConfiguration.m
@@ -1,3 +1,3 @@
 #import "WPEditorLoggingConfiguration.h"
 
-const int kEditorLogLevel = LOG_LEVEL_ERROR;
+const int kEditorLogLevel = DDLogLevelError;

--- a/Classes/WPLegacyEditorViewController.m
+++ b/Classes/WPLegacyEditorViewController.m
@@ -620,7 +620,7 @@ CGFloat const WPLegacyEPVCTextViewTopPadding = 7.0f;
 - (void)willAnimateRotationToInterfaceOrientation:(UIInterfaceOrientation)interfaceOrientation duration:(NSTimeInterval)duration
 {
     CGRect frame = self.editorToolbar.frame;
-    if (UIDeviceOrientationIsLandscape(interfaceOrientation)) {
+    if (UIInterfaceOrientationIsLandscape(interfaceOrientation)) {
         if (IS_IPAD) {
             frame.size.height = WPKT_HEIGHT_IPAD_LANDSCAPE;
         } else {

--- a/Example/EditorDemo/Base.lproj/Main_iPhone.storyboard
+++ b/Example/EditorDemo/Base.lproj/Main_iPhone.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="6254" systemVersion="13F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" initialViewController="Nm3-pN-0dt">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="7702" systemVersion="14D136" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" initialViewController="Nm3-pN-0dt">
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6247"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7701"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
     </dependencies>
     <scenes>

--- a/Example/EditorDemo/EditorDemo-Prefix.pch
+++ b/Example/EditorDemo/EditorDemo-Prefix.pch
@@ -13,6 +13,6 @@
 #ifdef __OBJC__
     #import <UIKit/UIKit.h>
     #import <Foundation/Foundation.h>
-    #import "DDLog.h"
+    #import <CocoaLumberjack/CocoaLumberjack.h>
     #import "WPEditorDemoLoggingConfiguration.h"
 #endif

--- a/Example/EditorDemo/WPAppDelegate.m
+++ b/Example/EditorDemo/WPAppDelegate.m
@@ -1,8 +1,6 @@
 #import "WPAppDelegate.h"
 
-#import <CocoaLumberjack/DDLog.h>
-#import <CocoaLumberjack/DDASLLogger.h>
-#import <CocoaLumberjack/DDTTYLogger.h>
+#import <CocoaLumberjack/CocoaLumberjack.h>
 #import <WordPress-iOS-Editor/WPEditorViewController.h>
 
 @implementation WPAppDelegate

--- a/Example/EditorDemo/WPEditorDemoLoggingConfiguration.h
+++ b/Example/EditorDemo/WPEditorDemoLoggingConfiguration.h
@@ -1,3 +1,3 @@
 #import <Foundation/Foundation.h>
 
-extern const int ddLogLevel;
+extern const DDLogLevel ddLogLevel;

--- a/Example/EditorDemo/WPEditorDemoLoggingConfiguration.h
+++ b/Example/EditorDemo/WPEditorDemoLoggingConfiguration.h
@@ -1,11 +1,3 @@
-//
-//  WPEditorDemoLoggingConfiguration.h
-//  EditorDemo
-//
-//  Created by Diego E. Rey Mendez on 10/7/14.
-//  Copyright (c) 2014 Automattic, Inc. All rights reserved.
-//
-
 #import <Foundation/Foundation.h>
 
 extern const int ddLogLevel;

--- a/Example/EditorDemo/WPEditorDemoLoggingConfiguration.m
+++ b/Example/EditorDemo/WPEditorDemoLoggingConfiguration.m
@@ -1,3 +1,3 @@
 #import "WPEditorDemoLoggingConfiguration.h"
 
-const int ddLogLevel = DDLogLevelError;
+const DDLogLevel ddLogLevel = DDLogLevelError;

--- a/Example/EditorDemo/WPEditorDemoLoggingConfiguration.m
+++ b/Example/EditorDemo/WPEditorDemoLoggingConfiguration.m
@@ -1,12 +1,3 @@
-//
-//  WPEditorDemoLoggingConfiguration.m
-//  EditorDemo
-//
-//  Created by Diego E. Rey Mendez on 10/7/14.
-//  Copyright (c) 2014 Automattic, Inc. All rights reserved.
-//
-
 #import "WPEditorDemoLoggingConfiguration.h"
-#import <CocoaLumberjack/DDLog.h>
 
-const int ddLogLevel = LOG_LEVEL_OFF;
+const int ddLogLevel = DDLogLevelError;

--- a/Example/EditorDemo/WPViewController.m
+++ b/Example/EditorDemo/WPViewController.m
@@ -2,7 +2,7 @@
 
 @import AssetsLibrary;
 @import AVFoundation;
-#import <CocoaLumberjack/DDLog.h>
+#import <CocoaLumberjack/CocoaLumberjack.h>
 #import "WPEditorField.h"
 #import "WPEditorView.h"
 #import "WPImageMetaViewController.h"

--- a/Example/Pods/Target Support Files/Pods-EditorDemo-WordPress-iOS-Editor/Pods-EditorDemo-WordPress-iOS-Editor-prefix.pch
+++ b/Example/Pods/Target Support Files/Pods-EditorDemo-WordPress-iOS-Editor/Pods-EditorDemo-WordPress-iOS-Editor-prefix.pch
@@ -12,7 +12,7 @@
 #ifdef __OBJC__
 #import <UIKit/UIKit.h>
 #import <Foundation/Foundation.h>
-#import "DDLog.h"
+#import <CocoaLumberjack/CocoaLumberjack.h>
 #import "WPEditorLoggingConfiguration.h"
 
 #ifndef IS_IPAD


### PR DESCRIPTION
Removes some header comments.

Also fixes some warnings regarding the use of `fabsf` with `CGFloat`, and regarding CocoaLumberjack too.

**How to test:**
1. Make sure the app builds.
2. Make sure the only remaining warning is about a constaint.
3. Make sure the demo app runs.