### PR TITLE
Added default separator to ZSSField.prototype.callback

### DIFF
--- a/Assets/ZSSRichTextEditor.js
+++ b/Assets/ZSSRichTextEditor.js
@@ -2579,7 +2579,7 @@ ZSSField.prototype.callback = function(callbackScheme, callbackPath) {
     var finalPath = "id=" + this.getNodeId();
     
     if (callbackPath && callbackPath.length > 0) {
-        finalPath = finalPath + callbackPath;
+        finalPath = finalPath + defaultCallbackSeparator + callbackPath;
     }
     
     this.callbacker.callback(callbackScheme, finalPath);


### PR DESCRIPTION
Fixes #681.

The ZSSField callback function was not adding the default separator after the `id` param and caused the url field in the edit link dialog to be blank. The broken URL in the link touched callback looked like this:

```
callback-link-tap:id=zss_field_contenturl=http%3A%2F%2Fwww.wordpress.com%2F~title=I'm%20a%20link!
```

and now is

```
callback-link-tap:id=zss_field_content~url=http%3A%2F%2Fwww.wordpress.com%2F~title=I'm%20a%20link!
```

(Note the extra `~` after `zss_field_content`) This also should fix any other callbacks done via ZSSField.

**How to test:**
* Edit and add links in the visual editor. Make sure correct URL and titles are displayed in the dialog.

/cc @SergioEstevao 
