### PR TITLE
Removed scrolling from format bar.

### DIFF
--- a/Classes/WPEditorToolbarView.h
+++ b/Classes/WPEditorToolbarView.h
@@ -71,6 +71,7 @@ typedef enum
     kWPEditorViewControllerElementRemoveFormatBarButton,
     kWPEditorViewControllerElementRemoveLinkBarButton,
     kWPEditorViewControllerElementShowSourceBarButton,
+    kWPEditorViewControllerElementiPhoneShowSourceBarButton,
     kWPEditorViewControllerElementStrikeThroughBarButton,
     kWPEditorViewControllerElementSubscriptBarButton,
     kWPEditorViewControllerElementSuperscriptBarButton,

--- a/Classes/WPEditorToolbarView.m
+++ b/Classes/WPEditorToolbarView.m
@@ -4,11 +4,11 @@
 #import "ZSSBarButtonItem.h"
 
 static int kDefaultToolbarItemPadding = 10;
-static int kDefaultToolbarLeftPadding = 10;
+static int kDefaultToolbarLeftPadding = 5;
 
-static int kNegativeToolbarItemPadding = 12;
-static int kNegativeSixToolbarItemPadding = 6;
-static int kNegativeSixPlusToolbarItemPadding = 2;
+static int kNegativeToolbarItemPadding = 16;
+static int kNegativeSixToolbarItemPadding = 10;
+static int kNegativeSixPlusToolbarItemPadding = 6;
 static int kNegativeLeftToolbarLeftPadding = 3;
 static int kNegativeRightToolbarPadding = 20;
 static int kNegativeSixPlusRightToolbarPadding = 24;
@@ -117,12 +117,7 @@ static const CGFloat WPEditorToolbarDividerLineWidth = 0.6;
         [items insertObject:negativeSeparator atIndex:i];
     }
     
-    UIBarButtonItem *negativeSeparatorForToolbar = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemFixedSpace
-                                                                                                 target:nil
-                                                                                                 action:nil];
     CGFloat finalToolbarLeftPadding = kDefaultToolbarLeftPadding - kNegativeLeftToolbarLeftPadding;
-    
-    negativeSeparatorForToolbar.width = -kNegativeLeftToolbarLeftPadding;
     toolbarWidth += finalToolbarLeftPadding;
     self.leftToolbar.items = items;
     self.leftToolbar.frame = CGRectMake(0.0, 0.0, toolbarWidth, WPEditorToolbarHeight);

--- a/Classes/WPEditorToolbarView.m
+++ b/Classes/WPEditorToolbarView.m
@@ -347,38 +347,16 @@ static const CGFloat WPEditorToolbarDividerLineWidth = 0.6;
 - (UIBarButtonItem*)htmlBarButtonItem
 {
     if (!_htmlBarButtonItem) {
-        UIBarButtonItem* htmlBarButtonItem =  [[UIBarButtonItem alloc] initWithTitle:@"HTML"
-                                                                               style:UIBarButtonItemStylePlain
-                                                                              target:nil
-                                                                              action:nil];
+        NSString* accessibilityLabel = NSLocalizedString(@"Display HTML",
+                                                         @"Accessibility label for display HTML button on formatting toolbar.");
         
-        UIFont * font = [UIFont boldSystemFontOfSize:10.0];
-        NSDictionary * attributes = @{NSFontAttributeName: font};
-        [htmlBarButtonItem setTitleTextAttributes:attributes forState:UIControlStateNormal];
-        htmlBarButtonItem.accessibilityLabel = NSLocalizedString(@"Display HTML",
-                                                                 @"Accessibility label for display HTML button on formatting toolbar.");
-        
-        CGRect customButtonFrame;
-        if (IS_IPAD) {
-            customButtonFrame = CGRectMake(0.0, 0.0, WPEditorToolbarButtonWidthiPad, WPEditorToolbarButtonHeightiPad);
-        } else {
-            customButtonFrame = CGRectMake(0.0, 0.0, WPEditorToolbarButtonWidth, WPEditorToolbarButtonHeight);
-        }
-        
-        WPEditorToolbarButton* customButton = [[WPEditorToolbarButton alloc] initWithFrame:customButtonFrame];
-        [customButton setTitle:@"HTML" forState:UIControlStateNormal];
-        customButton.normalTintColor = self.itemTintColor;
-        customButton.selectedTintColor = self.selectedItemTintColor;
-        customButton.disabledTintColor = self.disabledItemTintColor;
-        customButton.reversesTitleShadowWhenHighlighted = YES;
-        customButton.titleLabel.font = font;
-        [customButton addTarget:self
-                         action:@selector(showHTMLSource:)
-               forControlEvents:UIControlEventTouchUpInside];
-        
-        htmlBarButtonItem.customView = customButton;
-        
-        _htmlBarButtonItem = htmlBarButtonItem;
+        ZSSBarButtonItem *htmlButton = [self barButtonItemWithTag:kWPEditorViewControllerElementiPhoneShowSourceBarButton
+                                                        htmlProperty:@""
+                                                           imageName:@"icon_format_html"
+                                                              target:self
+                                                            selector:@selector(showHTMLSource:)
+                                                  accessibilityLabel:accessibilityLabel];
+        _htmlBarButtonItem = htmlButton;
     }
     
     return _htmlBarButtonItem;
@@ -505,14 +483,6 @@ static const CGFloat WPEditorToolbarDividerLineWidth = 0.6;
     
     for (WPEditorToolbarButton *item in self.leftToolbar.items) {
         item.disabledTintColor = _disabledItemTintColor;
-    }
-    
-    if (self.htmlBarButtonItem) {
-        WPEditorToolbarButton* htmlButton = (WPEditorToolbarButton*)self.htmlBarButtonItem.customView;
-        NSAssert([htmlButton isKindOfClass:[WPEditorToolbarButton class]],
-                 @"Expected to have an HTML button of class WPEditorToolbarButton here.");
-        
-        htmlButton.disabledTintColor = _disabledItemTintColor;
     }
 }
 

--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -7,1725 +7,1541 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		0118DC3FEF939C33E10A5434 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3FC1EFEC6EB6188975226AC3 /* Foundation.framework */; };
-		01B4626822D05E3B273321C4 /* UIProgressView+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = A27F58444DE8AE0E76350099 /* UIProgressView+AFNetworking.m */; };
-		020A23EB755E373D0C774FC4 /* CocoaLumberjack.h in Headers */ = {isa = PBXBuildFile; fileRef = F6EB761F023C2915B634E16C /* CocoaLumberjack.h */; };
-		031BF23E2C0CF4AE3999738C /* AFURLResponseSerialization.m in Sources */ = {isa = PBXBuildFile; fileRef = F399A5BAACE5836A5E67EF4C /* AFURLResponseSerialization.m */; };
-		032D2E088521A72F0735E2CC /* Merriweather-Light.ttf in Resources */ = {isa = PBXBuildFile; fileRef = A261037F1CFEE61E5ABF30E8 /* Merriweather-Light.ttf */; };
-		053980AF17F83BC2CE4078A1 /* HRBrightnessCursor.m in Sources */ = {isa = PBXBuildFile; fileRef = 98EE8483A445597F06C792DE /* HRBrightnessCursor.m */; };
-		054B1E3F683A9DDC12510EA4 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3FC1EFEC6EB6188975226AC3 /* Foundation.framework */; };
-		0672590DEED801308306313F /* NSString+Util.m in Sources */ = {isa = PBXBuildFile; fileRef = 8CA0CC8A3814CF370038663E /* NSString+Util.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-checker -Xanalyzer deadcode"; }; };
-		0679D5761D8BCD5A778FFBDB /* WPAnimatedImageResponseSerializer.h in Headers */ = {isa = PBXBuildFile; fileRef = 091546E15BC3F0E725600780 /* WPAnimatedImageResponseSerializer.h */; };
-		0855F7C21B79C5D5F9A540F0 /* Pods-EditorDemo-CocoaLumberjack-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 9D3595BFBDFDEB62A1D59A6D /* Pods-EditorDemo-CocoaLumberjack-dummy.m */; };
-		089901F315CD1C54C940C846 /* HRColorCursor.m in Sources */ = {isa = PBXBuildFile; fileRef = AB056485C7A7A2F6AE95F541 /* HRColorCursor.m */; };
-		089EA3D31D9BDC68F2E9DA49 /* WPEditorToolbarButton.m in Sources */ = {isa = PBXBuildFile; fileRef = AD955A9EED4C718A51BAF067 /* WPEditorToolbarButton.m */; };
-		08EF81487A47DB5758DCD18D /* DDASLLogCapture.m in Sources */ = {isa = PBXBuildFile; fileRef = 54676799AFC754686D4A4FEA /* DDASLLogCapture.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0 -w -Xanalyzer -analyzer-disable-checker -Xanalyzer deadcode"; }; };
-		095216B14586964134ED9258 /* WPNUXUtility.h in Headers */ = {isa = PBXBuildFile; fileRef = 1DF3E84B7B3532517590657B /* WPNUXUtility.h */; };
-		0A89547B2C05361CEC274F63 /* WPEditorLoggingConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = 768BD1B9A7536355AE0F9F15 /* WPEditorLoggingConfiguration.h */; };
-		0AE640F07A3A08E8DEDBF6FE /* WPFontManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 92029A24BD00438DF69F3430 /* WPFontManager.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-checker -Xanalyzer deadcode"; }; };
-		0D8A142AF6030770B9B21D9B /* WPEditorView.m in Sources */ = {isa = PBXBuildFile; fileRef = D8F18A6D0A8419F77D340D21 /* WPEditorView.m */; };
-		0DAD4E0A7CDE786B61E0C44B /* Pods-EditorDemo-WordPress-iOS-Editor-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = AD705BBE73395931249E6A99 /* Pods-EditorDemo-WordPress-iOS-Editor-dummy.m */; };
-		116BB4108DEA8D3D4CE63FDA /* Pods-EditorDemo-UIAlertView+Blocks-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 588DC83FD71E5DC28532E420 /* Pods-EditorDemo-UIAlertView+Blocks-dummy.m */; };
-		122EC76C9FC417183CFC3624 /* DDMultiFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = 7C3132720A59BC1DD7C4FCDE /* DDMultiFormatter.h */; };
-		12C2BD102767B4BC14379682 /* DDAssertMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = C80A806DD95999A06EF1959D /* DDAssertMacros.h */; };
-		13DD29457E8DE2A2908C0A72 /* UIActivityIndicatorView+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = C62728416E4B3FA0654C4627 /* UIActivityIndicatorView+AFNetworking.m */; };
-		14FFAB7D0B650855CA83819A /* UIAlertView+AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = 62A6F5B4248EC25962376F67 /* UIAlertView+AFNetworking.h */; };
-		151A63F36E8CB540E1A1827A /* UIColor+Helpers.h in Headers */ = {isa = PBXBuildFile; fileRef = EC8495EA7D6F0DE9DC90C99F /* UIColor+Helpers.h */; };
-		1751BC98C04280BBF48720E6 /* WPEditorView.h in Headers */ = {isa = PBXBuildFile; fileRef = E07BCBF46CA37C59069257EF /* WPEditorView.h */; };
-		19E2E264A61E6CF3FF0153E7 /* UIRefreshControl+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = 2F99BB982CA76B351FD5E532 /* UIRefreshControl+AFNetworking.m */; };
-		1A18695751BE30544DE70F7B /* UIButton+AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = 52ED6F51521BD3D073AD7AD4 /* UIButton+AFNetworking.h */; };
-		1A5ACF89528586C976AC9899 /* HRColorPickerViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 7170B9F00A185ACE9C143787 /* HRColorPickerViewController.h */; };
-		1C28F6C7964ACB9C77491AE7 /* AFURLSessionManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 87EBE2210918C1BB7DB448B5 /* AFURLSessionManager.h */; };
-		1C9A0E335DF329424FE720C7 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3FC1EFEC6EB6188975226AC3 /* Foundation.framework */; };
-		1C9ADAD2C4C9DFD71B61545F /* UITableViewTextFieldCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 9E986D24AFB113B21A461F3C /* UITableViewTextFieldCell.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-checker -Xanalyzer deadcode"; }; };
-		1CB9C776BB1B9DF6C4FF6C13 /* Pods-EditorDemo-WordPressCom-Analytics-iOS-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = A6BFF4669D8CBC787478BC99 /* Pods-EditorDemo-WordPressCom-Analytics-iOS-dummy.m */; };
-		1D83171BE4CD7ED42BFD2A7D /* WPEditorToolbarView.m in Sources */ = {isa = PBXBuildFile; fileRef = 55DF2E3BACB825D7471A8FEC /* WPEditorToolbarView.m */; };
-		1DE9A02057E3C3587D4D973A /* DDTTYLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = 1350BA0F996FFA831EED6BEB /* DDTTYLogger.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0 -w -Xanalyzer -analyzer-disable-checker -Xanalyzer deadcode"; }; };
-		1E25D29A9939FA3B713E03F1 /* WPEditorViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 88FA75E4F70D037B1EFAAF75 /* WPEditorViewController.m */; };
-		1EC80F743F1101E40461F989 /* HRColorPickerViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = FB0E6E4AEFB946AD32EF2296 /* HRColorPickerViewController.m */; };
-		1ECDFF15364658E3B24A8082 /* WPDeviceIdentification.m in Sources */ = {isa = PBXBuildFile; fileRef = 75EF4EE3B758B6379239E1E2 /* WPDeviceIdentification.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-checker -Xanalyzer deadcode"; }; };
-		1F2CEAFE3390A89C60266DBD /* AFHTTPSessionManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 943522988A655FD84657E486 /* AFHTTPSessionManager.m */; };
-		227248CA6CD7A79475224DAB /* WPEditorToolbarButton.h in Headers */ = {isa = PBXBuildFile; fileRef = 3ACCAC699D9B945C6C36B45F /* WPEditorToolbarButton.h */; };
-		237E2D37AEB16704A553434A /* AFSecurityPolicy.h in Headers */ = {isa = PBXBuildFile; fileRef = DFC722E6F6F78F683ECC3D33 /* AFSecurityPolicy.h */; };
-		245FD6C1DA22B17EC2F2FC3A /* DDLog+LOGV.h in Headers */ = {isa = PBXBuildFile; fileRef = 74357F1BFC1EC208F76D99A6 /* DDLog+LOGV.h */; };
-		2A04A6613CCF60FD474C5811 /* WPAnalytics.h in Headers */ = {isa = PBXBuildFile; fileRef = C6B28B188BC62FD0DDF829FC /* WPAnalytics.h */; };
-		2C679539F4112C521B2AFACE /* WPTableViewSectionFooterView.h in Headers */ = {isa = PBXBuildFile; fileRef = FDD4B3EA92489A784DB3B3E7 /* WPTableViewSectionFooterView.h */; };
-		2CEFDCB0FE3DB2F3C6DF498D /* DDLegacyMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 55D9883308BCDF32781C842C /* DDLegacyMacros.h */; };
-		2DD5BCF8D9F00B5DCF0245F0 /* UIKit+AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = 308AB52F92CBCF1CA62FEBCB /* UIKit+AFNetworking.h */; };
-		2EBAF12F3E723F4BA61E5287 /* AFSecurityPolicy.m in Sources */ = {isa = PBXBuildFile; fileRef = C92A8CEBF014239853F143AB /* AFSecurityPolicy.m */; };
-		32BD744D61A0B10D85546E85 /* Merriweather-Italic.otf in Resources */ = {isa = PBXBuildFile; fileRef = 327E6EC8D455841FD0FBEFE8 /* Merriweather-Italic.otf */; };
-		32FC4BC30B50E98C7447B0B7 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3FC1EFEC6EB6188975226AC3 /* Foundation.framework */; };
-		36C4082C5A62A93021A2C46A /* UIWebView+GUIFixes.h in Headers */ = {isa = PBXBuildFile; fileRef = F79DFC09DF5D304117C8C985 /* UIWebView+GUIFixes.h */; };
-		36F753DF5C5D5EEEFA27C993 /* UIWebView+GUIFixes.m in Sources */ = {isa = PBXBuildFile; fileRef = 6DB2247E9DE38BAB3598AA4F /* UIWebView+GUIFixes.m */; };
-		3747CD7DBDB033F9B16FBB52 /* WPFontManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 22CAAD3B6A1A315A25DDAC72 /* WPFontManager.h */; };
-		392E346EFB7317E6BB72DB12 /* Pods-EditorDemo-NSObject-SafeExpectations-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 1232CFE2F61607CF8870E363 /* Pods-EditorDemo-NSObject-SafeExpectations-dummy.m */; };
-		3955A7B079EE33C604A49AB0 /* UIWebView+AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = 52AD4EC065836A821A33C0DA /* UIWebView+AFNetworking.h */; };
-		3C3533D02DD976914780025B /* DDLegacyMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 55D9883308BCDF32781C842C /* DDLegacyMacros.h */; };
-		3CCDF32D30DC8B6031A75A28 /* DDASLLogCapture.h in Headers */ = {isa = PBXBuildFile; fileRef = 3DF5463DDA4D731C6A03FB50 /* DDASLLogCapture.h */; };
-		3D7CDF7525DCF86806FA1A80 /* CYRTextView.h in Headers */ = {isa = PBXBuildFile; fileRef = 34A701B8110E840B28A9D42B /* CYRTextView.h */; };
-		3DCC994222F09A501755A611 /* WPAnimatedImageResponseSerializer.m in Sources */ = {isa = PBXBuildFile; fileRef = 17A14C852C9344ACAE60A163 /* WPAnimatedImageResponseSerializer.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-checker -Xanalyzer deadcode"; }; };
-		3F5C1D81D55B3A781CADC46A /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3FC1EFEC6EB6188975226AC3 /* Foundation.framework */; };
-		40953DC82F87E7D16F7A72B5 /* DDContextFilterLogFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = 0DB2B67BABFAF4ED3D2ECB51 /* DDContextFilterLogFormatter.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0 -w -Xanalyzer -analyzer-disable-checker -Xanalyzer deadcode"; }; };
-		42DAFC39BD9D3B670F8C0F13 /* WPEditorLoggingConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = 79A01D6C15846ECFFE1686F3 /* WPEditorLoggingConfiguration.m */; };
-		46FC19FD4A98A96DFA00514B /* DDAssertMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = C80A806DD95999A06EF1959D /* DDAssertMacros.h */; };
-		477184D05437F19DA4166240 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3FC1EFEC6EB6188975226AC3 /* Foundation.framework */; };
-		4B0DB6F7D025A5066352BAF6 /* DDContextFilterLogFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = 0DB2B67BABFAF4ED3D2ECB51 /* DDContextFilterLogFormatter.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0 -w -Xanalyzer -analyzer-disable-checker -Xanalyzer deadcode"; }; };
-		4E62DCC1334267D8744BF900 /* WPTableViewSectionFooterView.m in Sources */ = {isa = PBXBuildFile; fileRef = 1B42E8DEA5EED6E7D484E62D /* WPTableViewSectionFooterView.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-checker -Xanalyzer deadcode"; }; };
-		528DA4EA1E7A88ED2192F6B7 /* DDFileLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = DF23B2473711D04DCCCF8D23 /* DDFileLogger.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0 -w -Xanalyzer -analyzer-disable-checker -Xanalyzer deadcode"; }; };
-		539541642E02EEF5C359ED7C /* DDAbstractDatabaseLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = 94D8943D1DD7246DC92AD2DB /* DDAbstractDatabaseLogger.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0 -w -Xanalyzer -analyzer-disable-checker -Xanalyzer deadcode"; }; };
-		58F48F2CBBAB6F1DFF84DD00 /* DDDispatchQueueLogFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = BA17E35CEDDB3D58BD6B6A8D /* DDDispatchQueueLogFormatter.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0 -w -Xanalyzer -analyzer-disable-checker -Xanalyzer deadcode"; }; };
-		59E50E935422D77016F3D309 /* DDAbstractDatabaseLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = 94D8943D1DD7246DC92AD2DB /* DDAbstractDatabaseLogger.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0 -w -Xanalyzer -analyzer-disable-checker -Xanalyzer deadcode"; }; };
-		5C2162DA09250C24CB89E11F /* AFURLConnectionOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 34ED3705F34F9E0B11228A4D /* AFURLConnectionOperation.h */; };
-		5D9B302E870953CBD6CAC2C7 /* AFHTTPRequestOperationManager.m in Sources */ = {isa = PBXBuildFile; fileRef = F6EEAF6E918D64B1B7AF9C33 /* AFHTTPRequestOperationManager.m */; };
-		5DA1FDF0605F8B3A6681E522 /* HRCgUtil.h in Headers */ = {isa = PBXBuildFile; fileRef = 1D4D93A62C39721D8A512F8F /* HRCgUtil.h */; };
-		5F90574FD42281DB4951457E /* UIAlertView+Blocks.h in Headers */ = {isa = PBXBuildFile; fileRef = 018979C89C385724745283B5 /* UIAlertView+Blocks.h */; };
-		614D39AEC68B48C3526B4B08 /* WPNUXUtility.m in Sources */ = {isa = PBXBuildFile; fileRef = 6D16E030A7855D156F8D6873 /* WPNUXUtility.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-checker -Xanalyzer deadcode"; }; };
-		61C97315AAD2F71789A4C2AA /* Pods-EditorDemoTests-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 59050B4B96496DFD8DD03035 /* Pods-EditorDemoTests-dummy.m */; };
-		623DE47FBB54662F2DF11DCF /* DDAbstractDatabaseLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = EF4686D53017634E6BEBA1CF /* DDAbstractDatabaseLogger.h */; };
-		63E28CC2686764246641D7A2 /* AFURLSessionManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 8EEF297308E4806240A577F9 /* AFURLSessionManager.m */; };
-		66F8AD65B213D1C70FAA0F97 /* DDTTYLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = 1350BA0F996FFA831EED6BEB /* DDTTYLogger.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0 -w -Xanalyzer -analyzer-disable-checker -Xanalyzer deadcode"; }; };
-		67A1C7836386B064584FC260 /* WPTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 09D1BCFC1F4E975478078E92 /* WPTableViewCell.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-checker -Xanalyzer deadcode"; }; };
-		6816C1EF210499DD5D3D88B2 /* AFHTTPRequestOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 6C616AE8E697E93A6E37DFF3 /* AFHTTPRequestOperation.m */; };
-		682CA74726C04205C0551787 /* WPImageMeta.m in Sources */ = {isa = PBXBuildFile; fileRef = BD1E570EF8189D86464C0E2C /* WPImageMeta.m */; };
-		69EB6174C3B4193515FDE7EF /* UIRefreshControl+AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = 433ED554028EF4893CAB653F /* UIRefreshControl+AFNetworking.h */; };
-		6BFAE6772D14F733C989F1E0 /* OpenSans-SemiboldItalic.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 4C1A99A1ED8BB763DDCF154F /* OpenSans-SemiboldItalic.ttf */; };
-		6E5200EF3D9D8A58CF6A2345 /* UIButton+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = D27F9BD3C4703DA8BD2AC9FB /* UIButton+AFNetworking.m */; };
-		6FA4467E1A9CFB46E0215CF3 /* HRCgUtil.m in Sources */ = {isa = PBXBuildFile; fileRef = 86B2B8EBE5E7BD54D211245F /* HRCgUtil.m */; };
-		708744E85D863852339B4E0B /* Merriweather-LightItalic.otf in Resources */ = {isa = PBXBuildFile; fileRef = BF05E9C99DBD7D58BD72C47B /* Merriweather-LightItalic.otf */; };
-		71580D39779F6D913C47D0EB /* DDTTYLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = 83B76071665DF829399714BF /* DDTTYLogger.h */; };
-		71E668178A0A56D58CFE4385 /* CYRLayoutManager.h in Headers */ = {isa = PBXBuildFile; fileRef = A82B16455309483C9C249630 /* CYRLayoutManager.h */; };
-		7202887560AFA7ADD7572AFE /* WPLegacyKeyboardToolbarBase.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FD2B36D886DFC8099841A0B /* WPLegacyKeyboardToolbarBase.h */; };
-		73A22ABE684857E2A567FC6E /* UIAlertView+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = 3DFF8FE68DF9DA0E3299D664 /* UIAlertView+AFNetworking.m */; };
-		779DD46D883D5F4E465C2436 /* DDASLLogCapture.h in Headers */ = {isa = PBXBuildFile; fileRef = 3DF5463DDA4D731C6A03FB50 /* DDASLLogCapture.h */; };
-		78D837083E1BD7C24E9EE23F /* WPLegacyKeyboardToolbarDone.h in Headers */ = {isa = PBXBuildFile; fileRef = B46B33D534E8A4F34D7096F7 /* WPLegacyKeyboardToolbarDone.h */; };
-		7A92D46090BA61F891D06EC8 /* DDDispatchQueueLogFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = 045EDAFF2CA6C9E03F1A9EFE /* DDDispatchQueueLogFormatter.h */; };
-		7F5221144D0E5C033AB0E23A /* CocoaLumberjack.h in Headers */ = {isa = PBXBuildFile; fileRef = F6EB761F023C2915B634E16C /* CocoaLumberjack.h */; };
-		7F9B7B6C92BBEBDC2777FD3A /* HRColorPickerView.h in Headers */ = {isa = PBXBuildFile; fileRef = 317C00A0F2D55B4BFD06B22E /* HRColorPickerView.h */; };
-		802E41D76C3B69CC11F0CD2F /* DDDispatchQueueLogFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = BA17E35CEDDB3D58BD6B6A8D /* DDDispatchQueueLogFormatter.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0 -w -Xanalyzer -analyzer-disable-checker -Xanalyzer deadcode"; }; };
-		81A78326C944FF2A248EB535 /* DDMultiFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = F8B92DA817029F2EA817CCD9 /* DDMultiFormatter.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0 -w -Xanalyzer -analyzer-disable-checker -Xanalyzer deadcode"; }; };
-		820476BEF888886774F2589C /* DDLog+LOGV.h in Headers */ = {isa = PBXBuildFile; fileRef = 74357F1BFC1EC208F76D99A6 /* DDLog+LOGV.h */; };
-		8572D7994C93A2F7C6084087 /* DDASLLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = 89235079FAB59221611D63CD /* DDASLLogger.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0 -w -Xanalyzer -analyzer-disable-checker -Xanalyzer deadcode"; }; };
-		8602F22FA0E18A5444960A68 /* WPLegacyKeyboardToolbarButtonItem.m in Sources */ = {isa = PBXBuildFile; fileRef = BCE044252C4D68BE0AF67ED8 /* WPLegacyKeyboardToolbarButtonItem.m */; };
-		8725DD98031BE3CBA839D67A /* NSDictionary+SafeExpectations.h in Headers */ = {isa = PBXBuildFile; fileRef = 176C9DE7D881606395EE8288 /* NSDictionary+SafeExpectations.h */; };
-		87C27ECAFA60B74EB62B71E5 /* DDASLLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = 98DF48F13D4655D8543E518B /* DDASLLogger.h */; };
-		880426EE3396B78733596F3A /* DDASLLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = 98DF48F13D4655D8543E518B /* DDASLLogger.h */; };
-		887C70DA5DB9D0011BCB3364 /* WPNoResultsView.m in Sources */ = {isa = PBXBuildFile; fileRef = 1DBF976142E1D7C7799DD0F9 /* WPNoResultsView.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-checker -Xanalyzer deadcode"; }; };
-		89E0E324AFB12A2A735FE947 /* HRColorCursor.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BEB2D35D07C89F0DFD67FCE /* HRColorCursor.h */; };
-		8C43DDF2C38969231D0A4DE3 /* WPNoResultsView.h in Headers */ = {isa = PBXBuildFile; fileRef = F1A9AB7D49A0C6AA9AEE8636 /* WPNoResultsView.h */; };
-		8D8A4825B184DBB76F2B95E2 /* OpenSans-Bold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 68863BCB654EC023916826BD /* OpenSans-Bold.ttf */; };
-		8F204FF966AD8B208DD0A0E8 /* UIProgressView+AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = 03307AB3857022B32EA286FF /* UIProgressView+AFNetworking.h */; };
-		90490ADBB98325B56BF50723 /* WPStyleGuide.m in Sources */ = {isa = PBXBuildFile; fileRef = 0AE80F9D135E74992FBF0F68 /* WPStyleGuide.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-checker -Xanalyzer deadcode"; }; };
-		917C876E258FF870B41E4BE9 /* AFURLResponseSerialization.h in Headers */ = {isa = PBXBuildFile; fileRef = 92FD2D1BB51543C99FB78845 /* AFURLResponseSerialization.h */; };
-		9193432B22F64F243D92D761 /* OpenSans-Italic.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 26E373A57F6558BBFBDC1667 /* OpenSans-Italic.ttf */; };
-		91F54F28ADAD33EB4927C1CC /* WPEditorToolbarView.h in Headers */ = {isa = PBXBuildFile; fileRef = 9D77FE1E5CA966152EEB3DE9 /* WPEditorToolbarView.h */; };
-		94BA1121967D85D72E70E7A4 /* AFURLRequestSerialization.m in Sources */ = {isa = PBXBuildFile; fileRef = 37AEC98F2495EC75AFBE14FC /* AFURLRequestSerialization.m */; };
-		98A27AC7FBA753CBC927C99F /* UIImageView+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = E55DD7A1E3B91C809FA29A87 /* UIImageView+AFNetworking.m */; };
-		98EE522FB09BA5B821A7A63F /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3FC1EFEC6EB6188975226AC3 /* Foundation.framework */; };
-		99339BF95DF0EED4E7CD6ECC /* WPImageSource.m in Sources */ = {isa = PBXBuildFile; fileRef = BC2035E92C1E87AA65F80397 /* WPImageSource.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-checker -Xanalyzer deadcode"; }; };
-		99ED38D1D677E229CFD167F3 /* DDASLLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = 89235079FAB59221611D63CD /* DDASLLogger.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0 -w -Xanalyzer -analyzer-disable-checker -Xanalyzer deadcode"; }; };
-		99FF042154967FC4B4149418 /* AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = D5213EE2040E6B3573D93D9A /* AFNetworking.h */; };
-		9A5297153F39809788FD4708 /* DDASLLogCapture.m in Sources */ = {isa = PBXBuildFile; fileRef = 54676799AFC754686D4A4FEA /* DDASLLogCapture.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0 -w -Xanalyzer -analyzer-disable-checker -Xanalyzer deadcode"; }; };
-		9A975DEB34852A685EB02A48 /* AFURLConnectionOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = B752A1B22EEBA84AAB04BC43 /* AFURLConnectionOperation.m */; };
-		9C4262218C1581A2254A983A /* CYRLayoutManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 9AFDF5C977A47006BC807E8F /* CYRLayoutManager.m */; };
-		9CDC135567217FBCE92A0C53 /* WPLegacyKeyboardToolbarButtonItem.h in Headers */ = {isa = PBXBuildFile; fileRef = BFF08FB8ED207559997CDFB2 /* WPLegacyKeyboardToolbarButtonItem.h */; };
-		9DF55F067502C0A89D23ED4B /* NSDictionary+SafeExpectations.m in Sources */ = {isa = PBXBuildFile; fileRef = BBFF0636DD0ACBEF7709787A /* NSDictionary+SafeExpectations.m */; };
-		A0D13B590FAE2303E26BF2A5 /* Merriweather-BoldItalic.otf in Resources */ = {isa = PBXBuildFile; fileRef = 060F276754F0350A2FA05117 /* Merriweather-BoldItalic.otf */; };
-		A258F59DA8E45E0B6969ADB2 /* WPLegacyEditorViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 80D829BCA25C76946462169A /* WPLegacyEditorViewController.m */; };
-		A484D2247DBCD95B894C3ADA /* OpenSans-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 6893DCC647C2B6A10590134B /* OpenSans-Regular.ttf */; };
-		A94150515F6697D6760627EE /* WPEditorField.m in Sources */ = {isa = PBXBuildFile; fileRef = 974D2A9D4653F8E38D2F0C40 /* WPEditorField.m */; };
-		ABDB15436BE40C6FF57DEEA0 /* DDLogMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 8D7EC5A03EE293E016E05897 /* DDLogMacros.h */; };
-		ABF0A37A746FB45AE5392D10 /* WPStyleGuide.h in Headers */ = {isa = PBXBuildFile; fileRef = 56E3A2813DD6D93629C0FD63 /* WPStyleGuide.h */; };
-		AFF7AEA94838565FC0DE4196 /* HRColorUtil.h in Headers */ = {isa = PBXBuildFile; fileRef = 8A38F0FFC96FDCCDD12B1AFA /* HRColorUtil.h */; };
-		B15CDB92D498DC63C3669B58 /* NSObject+SafeExpectations.h in Headers */ = {isa = PBXBuildFile; fileRef = B563C04BA3C2A510A9F8495F /* NSObject+SafeExpectations.h */; };
-		B2C9DF76B88C2B8AAD8207EF /* WPDeviceIdentification.h in Headers */ = {isa = PBXBuildFile; fileRef = AB0222DB5D4D25C5B5EA30BF /* WPDeviceIdentification.h */; };
-		B2F1C0DB2FB0673C695B20E8 /* CYRToken.m in Sources */ = {isa = PBXBuildFile; fileRef = D8B21B104C492B33C5198F0C /* CYRToken.m */; };
-		B32A76314129462DEFB82944 /* WPLegacyEditorViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = C403C7B8F58A796C79509BFB /* WPLegacyEditorViewController.h */; };
-		B5073CEB582B7CBE8E97B959 /* AFNetworkActivityIndicatorManager.h in Headers */ = {isa = PBXBuildFile; fileRef = CDBB1FD933AF6AF88966E053 /* AFNetworkActivityIndicatorManager.h */; };
-		B5F4FC87901E5EA1350AD590 /* CYRTextStorage.m in Sources */ = {isa = PBXBuildFile; fileRef = AB1B4D0769C3B24AF938ECE4 /* CYRTextStorage.m */; };
-		B6A5C66616BF39D655087172 /* WPEditorViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = EC99DF31A210C785E8C03009 /* WPEditorViewController.h */; };
-		B6BC073B5BC15EDCA96DBDD8 /* AFHTTPRequestOperationManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 4B0E4C244D73BA1DBC57A3ED /* AFHTTPRequestOperationManager.h */; };
-		B7886A7E24A421E5E55EFB7F /* MobileCoreServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5A5291133F8F6D24122120CE /* MobileCoreServices.framework */; };
-		B8F3BE4B3667C2B0827F9344 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3FC1EFEC6EB6188975226AC3 /* Foundation.framework */; };
-		B97844ED6D864BCA4601B8C1 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3FC1EFEC6EB6188975226AC3 /* Foundation.framework */; };
-		BA3B03CE80916430EE504961 /* NSString+Util.h in Headers */ = {isa = PBXBuildFile; fileRef = F7B60B3A45487A8D0FE93430 /* NSString+Util.h */; };
-		BDE8E5739C5A567ED4A0F7C2 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EBC991C6DFE83D4D4C3784D2 /* Security.framework */; };
-		BE4C2F69103020B047D2AF1F /* Pods-EditorDemoTests-CocoaLumberjack-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 5A8549A279C4AFD919B26398 /* Pods-EditorDemoTests-CocoaLumberjack-dummy.m */; };
-		BEBE39218171BC7FA3C9BA5B /* DDLogMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 8D7EC5A03EE293E016E05897 /* DDLogMacros.h */; };
-		BF263C8F625E32DBAFC0B273 /* UIImageView+AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = 4B28F424A4945347088E67AA /* UIImageView+AFNetworking.h */; };
-		BF759388B75EE19051D13DFC /* UIImage+Util.m in Sources */ = {isa = PBXBuildFile; fileRef = C177B27AF8DF7D5DDF5266C0 /* UIImage+Util.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-checker -Xanalyzer deadcode"; }; };
-		C0AFFBDE81608A5CB35CC881 /* HRBrightnessCursor.h in Headers */ = {isa = PBXBuildFile; fileRef = A83EBE9737B76BD1DB10EB25 /* HRBrightnessCursor.h */; };
-		C16A8EF683F5BBE375328608 /* DDLog.h in Headers */ = {isa = PBXBuildFile; fileRef = E32BBF04BBF9BDAF1DA8BD9D /* DDLog.h */; };
-		C1E6914A21C78F65D653E968 /* AFURLRequestSerialization.h in Headers */ = {isa = PBXBuildFile; fileRef = A48F9E3F5784859E655DB860 /* AFURLRequestSerialization.h */; };
-		C2316F9979DD7BBA4D3E688F /* DDFileLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = 310C01090D1A63E9DA5240B6 /* DDFileLogger.h */; };
-		C29A8459E1EFF811159DFFE3 /* UITableViewTextFieldCell.h in Headers */ = {isa = PBXBuildFile; fileRef = E50FB26B160A58EF2B22DC7E /* UITableViewTextFieldCell.h */; };
-		C490CEABA4A3E288169ED01F /* DDFileLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = DF23B2473711D04DCCCF8D23 /* DDFileLogger.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0 -w -Xanalyzer -analyzer-disable-checker -Xanalyzer deadcode"; }; };
-		C4BA77E8350D2F83778F2DCC /* DDDispatchQueueLogFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = 045EDAFF2CA6C9E03F1A9EFE /* DDDispatchQueueLogFormatter.h */; };
-		C624F0F06734AE0FA3B8E21E /* Merriweather-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 1D4D5A88C0F26EFC90814CB1 /* Merriweather-Regular.ttf */; };
-		C6682B4A07C0D42523566737 /* ZSSTextView.m in Sources */ = {isa = PBXBuildFile; fileRef = BBFFAAEA0B13ACEC5DCD402D /* ZSSTextView.m */; };
-		C67E431E9D6A0699BABB37B7 /* AFNetworkReachabilityManager.m in Sources */ = {isa = PBXBuildFile; fileRef = EF8E2060D208EF60883E9394 /* AFNetworkReachabilityManager.m */; };
-		C6EB57E0CDF62432156B4E60 /* HRColorUtil.m in Sources */ = {isa = PBXBuildFile; fileRef = DCAD6D44CF75602B883DB7B2 /* HRColorUtil.m */; };
-		C98E9D324188C3C118264584 /* DDMultiFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = 7C3132720A59BC1DD7C4FCDE /* DDMultiFormatter.h */; };
-		CB6DF23BB60BFD24507FCDF4 /* WPTableViewSectionHeaderView.m in Sources */ = {isa = PBXBuildFile; fileRef = 2AF247072D334D8C21A3B339 /* WPTableViewSectionHeaderView.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-checker -Xanalyzer deadcode"; }; };
-		CB7B6FAFE41001E0B3A26360 /* DDMultiFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = F8B92DA817029F2EA817CCD9 /* DDMultiFormatter.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0 -w -Xanalyzer -analyzer-disable-checker -Xanalyzer deadcode"; }; };
-		CB88DD0B0EA1AB9191230CE6 /* CYRToken.h in Headers */ = {isa = PBXBuildFile; fileRef = BC5F8CC72F610AF6F2377B5E /* CYRToken.h */; };
-		CD2060C74AB6D09E4386EAFA /* HRColorPickerMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = EFC7E7D7222CB606DE916907 /* HRColorPickerMacros.h */; };
-		CD4BDE29C5FFC1013B08FC8C /* ZSSTextView.h in Headers */ = {isa = PBXBuildFile; fileRef = 47CF243D1E5DAB7CF03588E9 /* ZSSTextView.h */; };
-		D0B79DEB6EC5E0E2BB9DF23A /* WPLegacyKeyboardToolbarBase.m in Sources */ = {isa = PBXBuildFile; fileRef = 018FA367567DFEC4AD1F893F /* WPLegacyKeyboardToolbarBase.m */; };
-		D1815F66707258EB336AFFA4 /* UIActivityIndicatorView+AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = D8204AE0034E79F2CE50C5C8 /* UIActivityIndicatorView+AFNetworking.h */; };
-		D49509718A9942A386E84882 /* HRColorPickerView.m in Sources */ = {isa = PBXBuildFile; fileRef = 924B5F6047D3307240D1F128 /* HRColorPickerView.m */; };
-		D5F3C06206C1C8D08F321A8C /* Merriweather-Bold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 056879325A78CF12075A1053 /* Merriweather-Bold.ttf */; };
-		D6C7CA58C892E2E26C66E48F /* WPEditorField.h in Headers */ = {isa = PBXBuildFile; fileRef = E7FE277C295E137B551C1D28 /* WPEditorField.h */; };
-		D7BF96479AEB6DFF02378851 /* CYRTextStorage.h in Headers */ = {isa = PBXBuildFile; fileRef = E7A1DB0FDF5244C4E92C208D /* CYRTextStorage.h */; };
-		D86632C887234BE2C4DA70CD /* DDLog.m in Sources */ = {isa = PBXBuildFile; fileRef = 865CB62E80D7764017A36D83 /* DDLog.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0 -w -Xanalyzer -analyzer-disable-checker -Xanalyzer deadcode"; }; };
-		D90FC966267BF90F2A7EE0FA /* UIImage+Util.h in Headers */ = {isa = PBXBuildFile; fileRef = 112CC384C22A5E4734216238 /* UIImage+Util.h */; };
-		D9889B21DF55981AF2EAE820 /* WPTableViewSectionHeaderView.h in Headers */ = {isa = PBXBuildFile; fileRef = D6E546B2C69B6D23F6A3175A /* WPTableViewSectionHeaderView.h */; };
-		DBA6CB07F9CF64491D9F4F3F /* OpenSans-Light.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 284390BBC552E83AAEA885A3 /* OpenSans-Light.ttf */; };
-		DBDF664E8B1DF327EC16D6C2 /* OpenSans-BoldItalic.ttf in Resources */ = {isa = PBXBuildFile; fileRef = A26F4D31A1E5025CB011DAB6 /* OpenSans-BoldItalic.ttf */; };
-		DC08879134FF6D09D48B84BA /* OpenSans-LightItalic.ttf in Resources */ = {isa = PBXBuildFile; fileRef = C2A651F702836255E1BF6923 /* OpenSans-LightItalic.ttf */; };
-		DC7D83E099F3C93714294186 /* WPTableViewCell.h in Headers */ = {isa = PBXBuildFile; fileRef = B76B72C0429B654F78ABED10 /* WPTableViewCell.h */; };
-		DD78E2DAA828A45F29D86603 /* UIWebView+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = 929BBF73903E060609B90773 /* UIWebView+AFNetworking.m */; };
-		DE8063EC0AE193C2E0EBF6A6 /* DDAbstractDatabaseLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = EF4686D53017634E6BEBA1CF /* DDAbstractDatabaseLogger.h */; };
-		DF430A365E88AEA8C53FD9D5 /* DDFileLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = 310C01090D1A63E9DA5240B6 /* DDFileLogger.h */; };
-		E118BA870BE5067A4C4E1248 /* UIColor+Helpers.m in Sources */ = {isa = PBXBuildFile; fileRef = 14F28812D5D2F11A0E018098 /* UIColor+Helpers.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-checker -Xanalyzer deadcode"; }; };
-		E3CC00ED2F3790D318243726 /* DDLog.h in Headers */ = {isa = PBXBuildFile; fileRef = E32BBF04BBF9BDAF1DA8BD9D /* DDLog.h */; };
-		E4A4432F93C38D9508C32E2E /* OpenSans-Semibold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 3CDF9ED71C9C92EC63F6BFBE /* OpenSans-Semibold.ttf */; };
-		E56666F7DBCE6128F58A3564 /* AFHTTPSessionManager.h in Headers */ = {isa = PBXBuildFile; fileRef = F957BAE1810901BBCD142A36 /* AFHTTPSessionManager.h */; };
-		E73055EAB6F88901B0F7EE62 /* WPImageMeta.h in Headers */ = {isa = PBXBuildFile; fileRef = 70DBC5EA925BD6CF3676657A /* WPImageMeta.h */; };
-		E73503A5CA850B4EB263D594 /* DDContextFilterLogFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = 5D4410C08BCC867F603078B4 /* DDContextFilterLogFormatter.h */; };
-		E8347C53F5D8070FB7767B18 /* DDContextFilterLogFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = 5D4410C08BCC867F603078B4 /* DDContextFilterLogFormatter.h */; };
-		E8796A2ECA9AC7D9D2712D19 /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8931B68A09E383CD904DD45B /* SystemConfiguration.framework */; };
-		E8B5B320F2EBBBE7FDBFE363 /* AFHTTPRequestOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 5C7240FA870002C3B38EB209 /* AFHTTPRequestOperation.h */; };
-		EB9AF8DB95DA0B7CFCC670A3 /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E1851933ADEEDE4F6D7433FC /* CoreGraphics.framework */; };
-		ED6CB2637670B71E629F1BF5 /* WPImageSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 62FDA82F50D9AB1BF1110A0B /* WPImageSource.h */; };
-		EFB786CC8A93244F0C1ECDCF /* NSString+XMLExtensions.h in Headers */ = {isa = PBXBuildFile; fileRef = 3B5573793DECA2290AFBAA22 /* NSString+XMLExtensions.h */; };
-		F40487AA465CA6A70E7E4277 /* UIAlertView+Blocks.m in Sources */ = {isa = PBXBuildFile; fileRef = 3BA661786D95821487D4AE8F /* UIAlertView+Blocks.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0 -w -Xanalyzer -analyzer-disable-checker -Xanalyzer deadcode"; }; };
-		F57DD9B800E1DADC70DE5968 /* WPLegacyKeyboardToolbarDone.m in Sources */ = {isa = PBXBuildFile; fileRef = BED91EE72D776DEC97ED65AC /* WPLegacyKeyboardToolbarDone.m */; };
-		F7F27FACC6AF47C9939727B1 /* ZSSBarButtonItem.h in Headers */ = {isa = PBXBuildFile; fileRef = C569177FBD9DC3B1C3D9A082 /* ZSSBarButtonItem.h */; };
-		F83199F7211C6267C36910F5 /* AFNetworkActivityIndicatorManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 1E5D8ED20A690A5DA0A2E877 /* AFNetworkActivityIndicatorManager.m */; };
-		F8D76B8118E439C3ED90BCA4 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3FC1EFEC6EB6188975226AC3 /* Foundation.framework */; };
-		F9E378B8916903EA9EB19BB5 /* ZSSBarButtonItem.m in Sources */ = {isa = PBXBuildFile; fileRef = B1D6D1525F0819EBB8B9A02D /* ZSSBarButtonItem.m */; };
-		FB8C14D68B4A80775773DC59 /* DDLog.m in Sources */ = {isa = PBXBuildFile; fileRef = 865CB62E80D7764017A36D83 /* DDLog.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0 -w -Xanalyzer -analyzer-disable-checker -Xanalyzer deadcode"; }; };
-		FCAA73E57BB49D2B7665D4EF /* Pods-EditorDemo-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = AACF3AC0715A74F944856827 /* Pods-EditorDemo-dummy.m */; };
-		FD8946BEFE65628074965029 /* NSString+XMLExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = A23DAF8B4FD9C9CA1D33FEBD /* NSString+XMLExtensions.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-checker -Xanalyzer deadcode"; }; };
-		FDD54CD64EE9508D3A210AB3 /* Pods-EditorDemo-AFNetworking-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 59BCCAA21F5127D63C97A477 /* Pods-EditorDemo-AFNetworking-dummy.m */; };
-		FDE18071A718A7FA522EF298 /* Pods-EditorDemo-WordPress-iOS-Shared-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 47A628B62C503D38F07D5D22 /* Pods-EditorDemo-WordPress-iOS-Shared-dummy.m */; };
-		FE14057D1C15D165C8A6C72D /* AFNetworkReachabilityManager.h in Headers */ = {isa = PBXBuildFile; fileRef = DECA1FA5912BF385D4C72FBA /* AFNetworkReachabilityManager.h */; };
-		FE5C92CE7AF11FB4E90AC624 /* CYRTextView.m in Sources */ = {isa = PBXBuildFile; fileRef = 280FCC792BA9A1849E28B5E3 /* CYRTextView.m */; };
-		FE8B0D33557734A70A37B024 /* DDTTYLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = 83B76071665DF829399714BF /* DDTTYLogger.h */; };
-		FFDEB51E3C46E9F4FF8D5FF9 /* WPAnalytics.m in Sources */ = {isa = PBXBuildFile; fileRef = F9BD038AD678226BAB2F4E6F /* WPAnalytics.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-checker -Xanalyzer deadcode"; }; };
+		00B315BA0F840005A32E0273 /* AFHTTPSessionManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 17836B3819D3E41E6A225C3E /* AFHTTPSessionManager.h */; };
+		00EACB7821F28A5604C335D0 /* UIImage+Util.h in Headers */ = {isa = PBXBuildFile; fileRef = B97B1EE3D83CF6F0BBAD6C5B /* UIImage+Util.h */; };
+		020EC4F208ACE02A1A56701D /* Merriweather-BoldItalic.otf in Resources */ = {isa = PBXBuildFile; fileRef = 849E16B8E6FBAD38FBBB605A /* Merriweather-BoldItalic.otf */; };
+		02612EC75199A0BD8B6C3128 /* UITableViewTextFieldCell.m in Sources */ = {isa = PBXBuildFile; fileRef = D5B41411BF9D5EF07E5B975D /* UITableViewTextFieldCell.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-checker -Xanalyzer deadcode"; }; };
+		030ECDF1ED13FD94C441B8D2 /* DDLog+LOGV.h in Headers */ = {isa = PBXBuildFile; fileRef = 2BB856A005EC089D8C5D43C8 /* DDLog+LOGV.h */; };
+		04602B3981D5E6CE7F7E5A56 /* DDAbstractDatabaseLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = 18FBB2E8FC94F4DD1F05C44B /* DDAbstractDatabaseLogger.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0 -w -Xanalyzer -analyzer-disable-checker -Xanalyzer deadcode"; }; };
+		0584C5259E1E816E59A3D05B /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1715BBEFB6401E99EA712D71 /* Foundation.framework */; };
+		058A3A79B349A915456E5032 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1715BBEFB6401E99EA712D71 /* Foundation.framework */; };
+		0678FD38EDC7B6368A846A94 /* HRColorCursor.h in Headers */ = {isa = PBXBuildFile; fileRef = 03681D95AF9171E060FCCA7E /* HRColorCursor.h */; };
+		0725DE584377196935DFD0BD /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 94393AB1696E6A7F79B8DFAF /* CoreGraphics.framework */; };
+		087BCAEFA37468C79A3B0069 /* NSString+Util.h in Headers */ = {isa = PBXBuildFile; fileRef = 42A02C404A0FB82B3E225C21 /* NSString+Util.h */; };
+		0B084D02CC892F604F635E57 /* WPAnalytics.m in Sources */ = {isa = PBXBuildFile; fileRef = 5B2680213E17A1E146706669 /* WPAnalytics.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-checker -Xanalyzer deadcode"; }; };
+		0BCC9303774F5B3E5E86C7E8 /* UIWebView+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = 1D5487200DB87D47FC5C41C6 /* UIWebView+AFNetworking.m */; };
+		0C2C861B920A7ADA284E29FD /* DDDispatchQueueLogFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = 07FAE5BC824445454A51531B /* DDDispatchQueueLogFormatter.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0 -w -Xanalyzer -analyzer-disable-checker -Xanalyzer deadcode"; }; };
+		0CC40EE7CE8663BE425A3C8E /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1715BBEFB6401E99EA712D71 /* Foundation.framework */; };
+		0CFD44BBF2ACE66FC66876E3 /* DDASLLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = 11E91DAED85154EDDD70659B /* DDASLLogger.h */; };
+		0DB8E628A62D32050167ACE2 /* WPImageMeta.m in Sources */ = {isa = PBXBuildFile; fileRef = C5B61413E187F9BC0C37CEE1 /* WPImageMeta.m */; };
+		0F70F37CA698BE7892F92DF1 /* Merriweather-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = A5B427F064254477FBBD5E6D /* Merriweather-Regular.ttf */; };
+		117434C0D7D67DB426CFFCCD /* UIProgressView+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = CCD50474AD55C76E4C71F5C6 /* UIProgressView+AFNetworking.m */; };
+		11A94BCCBB13A7303267378D /* WPEditorField.m in Sources */ = {isa = PBXBuildFile; fileRef = 6C1DD8384513A2FD9BB9C2AE /* WPEditorField.m */; };
+		13CCBAD9E4B5E68BBBCAB4AB /* CocoaLumberjack.h in Headers */ = {isa = PBXBuildFile; fileRef = C72782E3AFB1B33B1F0EB082 /* CocoaLumberjack.h */; };
+		14A8DAE9CF6DEAA45AD06B4A /* UIWebView+AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = D8AF1A872FF52CB9CD476958 /* UIWebView+AFNetworking.h */; };
+		15FED5B86773D58516FB6832 /* AFURLResponseSerialization.h in Headers */ = {isa = PBXBuildFile; fileRef = 331E0B9FC63B0EB5802BCC21 /* AFURLResponseSerialization.h */; };
+		1702D9526E67742556A0309C /* WPAnimatedImageResponseSerializer.m in Sources */ = {isa = PBXBuildFile; fileRef = E27B8D0B439915F8D923D746 /* WPAnimatedImageResponseSerializer.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-checker -Xanalyzer deadcode"; }; };
+		173A733C2FE16FDBB9A38ABA /* WPEditorLoggingConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = 90FD1475E81FF37A85C5BF31 /* WPEditorLoggingConfiguration.m */; };
+		19212F63A9E774760E50F180 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1715BBEFB6401E99EA712D71 /* Foundation.framework */; };
+		1A424E2B5B049C8FAFB83479 /* UIAlertView+Blocks.h in Headers */ = {isa = PBXBuildFile; fileRef = F9AB73690ECF3D21F89D27F4 /* UIAlertView+Blocks.h */; };
+		1C4808DF15B1E4FAE726E77D /* DDAbstractDatabaseLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = 6F9D799883EEAFA57E678C3F /* DDAbstractDatabaseLogger.h */; };
+		1CDE6EFB5B9278EA6D873930 /* DDFileLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = B47F30258990ECA0D498A47A /* DDFileLogger.h */; };
+		1E27E19030289822CBF33FC8 /* WPEditorViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 7A17FE572B152A4B1AFCC6EF /* WPEditorViewController.m */; };
+		1E9F86C4E0ADAE74026F0D81 /* UIRefreshControl+AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = 341CC9FE4B6F4A8B762446E2 /* UIRefreshControl+AFNetworking.h */; };
+		1FD20E00092B54DCF96DB9A4 /* DDLog.m in Sources */ = {isa = PBXBuildFile; fileRef = 3FC7FAE84FBA1C2DC3791B12 /* DDLog.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0 -w -Xanalyzer -analyzer-disable-checker -Xanalyzer deadcode"; }; };
+		20136684E7E621794A2A27CB /* NSDictionary+SafeExpectations.m in Sources */ = {isa = PBXBuildFile; fileRef = 37AAC3B7B3A2C70273F4B3D2 /* NSDictionary+SafeExpectations.m */; };
+		20A7036A9B13188247DEABE1 /* HRColorPickerView.h in Headers */ = {isa = PBXBuildFile; fileRef = A7D62E2AEE9F4BDDAF121FB7 /* HRColorPickerView.h */; };
+		214FF1C9E8E55F2FDC5CA1B2 /* DDAssertMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 737A955B6AB464B3A2DEECD7 /* DDAssertMacros.h */; };
+		245B8BBB4019CD0E1FC55348 /* DDLegacyMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = C6953FD23C17AD12497FBB0F /* DDLegacyMacros.h */; };
+		24C831C00EDE4DA26BF1B4E1 /* AFURLRequestSerialization.m in Sources */ = {isa = PBXBuildFile; fileRef = C6805C816ED05AC8A28D47E4 /* AFURLRequestSerialization.m */; };
+		265A082E9E4CE2831BFE4846 /* AFHTTPRequestOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 8673BA9704033A8EDE356D91 /* AFHTTPRequestOperation.h */; };
+		265E502EE5AD1B6920FEF301 /* CYRLayoutManager.h in Headers */ = {isa = PBXBuildFile; fileRef = C8F378A41CF4CCD2565AA20A /* CYRLayoutManager.h */; };
+		26B63962D93E8C57912D3673 /* WPEditorToolbarButton.h in Headers */ = {isa = PBXBuildFile; fileRef = 70967CF7678EDC88A3D32E0F /* WPEditorToolbarButton.h */; };
+		26C7CD786E631628F76A32BC /* DDLog.m in Sources */ = {isa = PBXBuildFile; fileRef = 3FC7FAE84FBA1C2DC3791B12 /* DDLog.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0 -w -Xanalyzer -analyzer-disable-checker -Xanalyzer deadcode"; }; };
+		295815DC817F873B9B775EBD /* DDTTYLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = BFF4FBE75092CC85C45662DD /* DDTTYLogger.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0 -w -Xanalyzer -analyzer-disable-checker -Xanalyzer deadcode"; }; };
+		2C3B4719A29463EACF55D3A9 /* DDMultiFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = 17AFACC2BDB34CFFF477DD38 /* DDMultiFormatter.h */; };
+		2C9AED1E162E565FACB9A6A9 /* UIAlertView+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = F92539183359EB4FF19CD625 /* UIAlertView+AFNetworking.m */; };
+		2DA1701E1374F4490EA6E4D9 /* AFHTTPRequestOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 0F282BBD8F9CEAA3F56CFACF /* AFHTTPRequestOperation.m */; };
+		2E11231A7C07813C1242646D /* UIActivityIndicatorView+AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = F6D4DB0B4FBE1F6A662937D5 /* UIActivityIndicatorView+AFNetworking.h */; };
+		2E98DC2BE05BEC96145E716A /* DDASLLogCapture.m in Sources */ = {isa = PBXBuildFile; fileRef = 49950677A0673A43329414AE /* DDASLLogCapture.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0 -w -Xanalyzer -analyzer-disable-checker -Xanalyzer deadcode"; }; };
+		2EB9FF3EBEA1AD9DDB0981D3 /* WPNoResultsView.h in Headers */ = {isa = PBXBuildFile; fileRef = C986ECA9682A194B494E39FD /* WPNoResultsView.h */; };
+		2FF2C3AD24039BFC59EAD3B2 /* WPStyleGuide.h in Headers */ = {isa = PBXBuildFile; fileRef = 2FAC1F4B3EA04E156178F03A /* WPStyleGuide.h */; };
+		30E0A9BDCC6FA0306F1C9936 /* AFURLSessionManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 64F72B8A17254D806052C879 /* AFURLSessionManager.h */; };
+		32510E954AEDD7929064B07B /* DDLogMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 18A705C1D1A09576152A5618 /* DDLogMacros.h */; };
+		35C586DBF19F15B25A53C307 /* ZSSBarButtonItem.h in Headers */ = {isa = PBXBuildFile; fileRef = 5003CDF4976CB62213B55E95 /* ZSSBarButtonItem.h */; };
+		35DB7B3006D92E5ECA2AF438 /* DDContextFilterLogFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = B11EEE44A00709A906D350E0 /* DDContextFilterLogFormatter.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0 -w -Xanalyzer -analyzer-disable-checker -Xanalyzer deadcode"; }; };
+		37824F02D7B16A549BE2B98C /* DDLog.h in Headers */ = {isa = PBXBuildFile; fileRef = 459E24005B62319A7867BFB3 /* DDLog.h */; };
+		37B9C1E91E2ABA7305271950 /* UIImageView+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = 28868A31B71EE7737F86D101 /* UIImageView+AFNetworking.m */; };
+		37F845EB1643CAA07B3DEEC3 /* CYRTextView.m in Sources */ = {isa = PBXBuildFile; fileRef = C4D86EFAE2EDA6F2B3557225 /* CYRTextView.m */; };
+		3841FA571435911B393A3EA6 /* HRColorPickerMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = C83A43068A5FFDDFCA024565 /* HRColorPickerMacros.h */; };
+		3AA484C0C473BE9F2475EA51 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1715BBEFB6401E99EA712D71 /* Foundation.framework */; };
+		3B1A90CA5EBDBCCF4C5784A6 /* WPFontManager.h in Headers */ = {isa = PBXBuildFile; fileRef = DF0EE4D20EF36C3B74332D25 /* WPFontManager.h */; };
+		3C39D9AA17DD2976390423A0 /* DDASLLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = 11E91DAED85154EDDD70659B /* DDASLLogger.h */; };
+		3E3F64C4F7C7ECA9CE6BFE23 /* Pods-EditorDemo-UIAlertView+Blocks-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 2FC4A195DA0EB213FF64569A /* Pods-EditorDemo-UIAlertView+Blocks-dummy.m */; };
+		3F951707702C9D751319C4B9 /* NSObject+SafeExpectations.h in Headers */ = {isa = PBXBuildFile; fileRef = 1D5E3538FDAB7AD423034561 /* NSObject+SafeExpectations.h */; };
+		40150A015D44DCC879F2B267 /* WPEditorLoggingConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = FC8742FD7D643EDCFFE1A2A0 /* WPEditorLoggingConfiguration.h */; };
+		409DD2DF1792D67A24582A9A /* WPEditorToolbarView.m in Sources */ = {isa = PBXBuildFile; fileRef = A5CAF1034DE3F578EB766D29 /* WPEditorToolbarView.m */; };
+		41040B9C67E75BDB940D56E8 /* AFSecurityPolicy.h in Headers */ = {isa = PBXBuildFile; fileRef = 2ED670FD22CA40E59803C5DA /* AFSecurityPolicy.h */; };
+		43B35A5FC4CE86AFF862D8CA /* OpenSans-Bold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 35B5684797DBC61EB1EDE504 /* OpenSans-Bold.ttf */; };
+		456DF8572B87B1ED58646325 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1715BBEFB6401E99EA712D71 /* Foundation.framework */; };
+		48379B04A0BBC6AFC7A2A791 /* AFNetworkActivityIndicatorManager.m in Sources */ = {isa = PBXBuildFile; fileRef = EAC99E4AE0F997449AD088F4 /* AFNetworkActivityIndicatorManager.m */; };
+		4947305BC71AA2E94669302C /* DDLog.h in Headers */ = {isa = PBXBuildFile; fileRef = 459E24005B62319A7867BFB3 /* DDLog.h */; };
+		49ACCB357615B4CEBCE11181 /* NSDictionary+SafeExpectations.h in Headers */ = {isa = PBXBuildFile; fileRef = 7754A6100490930D0A6F22A2 /* NSDictionary+SafeExpectations.h */; };
+		4A5B47755A7CB798A393153D /* NSString+Util.m in Sources */ = {isa = PBXBuildFile; fileRef = 5FC5BB613559A5EF42318132 /* NSString+Util.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-checker -Xanalyzer deadcode"; }; };
+		4AEEC8B0999760BE1EEEA55C /* WPImageSource.m in Sources */ = {isa = PBXBuildFile; fileRef = F79DE4F12605DE4BD7A9B387 /* WPImageSource.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-checker -Xanalyzer deadcode"; }; };
+		4BF6ACC1FD6B68EEB8AECD84 /* WPLegacyKeyboardToolbarButtonItem.h in Headers */ = {isa = PBXBuildFile; fileRef = A3667D4368AC7BD98AB11EBE /* WPLegacyKeyboardToolbarButtonItem.h */; };
+		4C33EF1B6D15BBB80E8124B2 /* WPAnimatedImageResponseSerializer.h in Headers */ = {isa = PBXBuildFile; fileRef = E5F5019259C6F329D71795FC /* WPAnimatedImageResponseSerializer.h */; };
+		4C7BD9820947738968D2A0A0 /* OpenSans-LightItalic.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 22D44D1AE026AFC29A21973D /* OpenSans-LightItalic.ttf */; };
+		4EF58884974D9DC28DB0315A /* UIButton+AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = 3E6FC2D20653D35A47ABB183 /* UIButton+AFNetworking.h */; };
+		4F195D16BEDDF05548D3C8EE /* WPStyleGuide.m in Sources */ = {isa = PBXBuildFile; fileRef = 62DB79E852F20BF71B5EA023 /* WPStyleGuide.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-checker -Xanalyzer deadcode"; }; };
+		4F3002AE2E1E312696A858A7 /* DDTTYLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = 3F5A6E8E30BFB77E50AE57EE /* DDTTYLogger.h */; };
+		51925EAFFD9C5D45D5430D31 /* WPLegacyEditorViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 408293AB03EE4D0333F59F94 /* WPLegacyEditorViewController.h */; };
+		5331834C1D64D40F4A387598 /* WPImageMeta.h in Headers */ = {isa = PBXBuildFile; fileRef = 6B5871EF1DB454680B239044 /* WPImageMeta.h */; };
+		53FC0F35997842C8E018848F /* WPEditorToolbarButton.m in Sources */ = {isa = PBXBuildFile; fileRef = AA1A34EBC1C052DDD1904412 /* WPEditorToolbarButton.m */; };
+		5690DC123A170E12C141E5C1 /* HRBrightnessCursor.h in Headers */ = {isa = PBXBuildFile; fileRef = 74442FB3EEB4B3483B2DE99F /* HRBrightnessCursor.h */; };
+		574E72B245124E1F6D39DD9E /* HRColorPickerViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 749D6965D9B4AC4956B45D4A /* HRColorPickerViewController.m */; };
+		5752114E2C2BBDEFD164D84A /* WPLegacyKeyboardToolbarButtonItem.m in Sources */ = {isa = PBXBuildFile; fileRef = 83D6D3668F3C091493AE9921 /* WPLegacyKeyboardToolbarButtonItem.m */; };
+		57BC607CDF29EC50A462F224 /* DDTTYLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = 3F5A6E8E30BFB77E50AE57EE /* DDTTYLogger.h */; };
+		58F2EDB671C1BCA7B4FDF2D1 /* DDDispatchQueueLogFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = 77241CD57509022AF218143E /* DDDispatchQueueLogFormatter.h */; };
+		5A4E733842D7574E5ACD7049 /* CYRToken.h in Headers */ = {isa = PBXBuildFile; fileRef = 538275645AFBCEE7FF7065A1 /* CYRToken.h */; };
+		5C3FC1803741E21BEBA4CD96 /* HRColorUtil.h in Headers */ = {isa = PBXBuildFile; fileRef = E667E8C13719F24F6E718AD9 /* HRColorUtil.h */; };
+		5D1472B85D5FA71B9F9E5003 /* OpenSans-SemiboldItalic.ttf in Resources */ = {isa = PBXBuildFile; fileRef = ECABBDDEFD7029DCC1CF274C /* OpenSans-SemiboldItalic.ttf */; };
+		5E4A81CEBDF75A3E45A3FE6B /* HRColorPickerViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 1838BF695A15C46138327B6A /* HRColorPickerViewController.h */; };
+		5EFDDC9C170F7A7BE41B666A /* CocoaLumberjack.h in Headers */ = {isa = PBXBuildFile; fileRef = C72782E3AFB1B33B1F0EB082 /* CocoaLumberjack.h */; };
+		5FB3010F22AEA24CA3669054 /* Pods-EditorDemoTests-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = D3B1F964851055DB409A90BB /* Pods-EditorDemoTests-dummy.m */; };
+		601B44FB8FF5B3073C52C654 /* WPTableViewSectionFooterView.m in Sources */ = {isa = PBXBuildFile; fileRef = 92734290DB026F15AF179C9A /* WPTableViewSectionFooterView.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-checker -Xanalyzer deadcode"; }; };
+		6269D7331C3895524227D81E /* WPLegacyKeyboardToolbarDone.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F2E7064DF0BA8CF58089FB9 /* WPLegacyKeyboardToolbarDone.m */; };
+		632B4277B4D76246ADAA3731 /* DDLog+LOGV.h in Headers */ = {isa = PBXBuildFile; fileRef = 2BB856A005EC089D8C5D43C8 /* DDLog+LOGV.h */; };
+		63BF1CD1F1C1AF2014347D50 /* DDDispatchQueueLogFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = 07FAE5BC824445454A51531B /* DDDispatchQueueLogFormatter.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0 -w -Xanalyzer -analyzer-disable-checker -Xanalyzer deadcode"; }; };
+		6510CBADBA028F03DB4F47D8 /* UIProgressView+AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = C94387FAC53D4EF4B2DDDAE4 /* UIProgressView+AFNetworking.h */; };
+		66006C47AE6A612215C18B6C /* UITableViewTextFieldCell.h in Headers */ = {isa = PBXBuildFile; fileRef = 7A4CAA54E3B816D1E4362729 /* UITableViewTextFieldCell.h */; };
+		665078E8CB067A5A83DBC8D0 /* DDContextFilterLogFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = 2E66D244D542F23A3C2B98C2 /* DDContextFilterLogFormatter.h */; };
+		66B8653EF63CA90D21A2A380 /* HRColorUtil.m in Sources */ = {isa = PBXBuildFile; fileRef = B163A43834E87052599E6D53 /* HRColorUtil.m */; };
+		67C20A77404F2021E7DDB36B /* NSString+XMLExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = 9B32D85834184C4D9047C37D /* NSString+XMLExtensions.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-checker -Xanalyzer deadcode"; }; };
+		67F2D02E6FC3F13CC722096C /* AFURLResponseSerialization.m in Sources */ = {isa = PBXBuildFile; fileRef = 558641644DB1BF02BEB5DC0F /* AFURLResponseSerialization.m */; };
+		682E24244A4D196F54425E8F /* UIAlertView+Blocks.m in Sources */ = {isa = PBXBuildFile; fileRef = 199BD5014705CEACB439CE05 /* UIAlertView+Blocks.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0 -w -Xanalyzer -analyzer-disable-checker -Xanalyzer deadcode"; }; };
+		6A3196A1CD5D0C95B6031AEB /* Pods-EditorDemo-WordPress-iOS-Editor-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = C103205F3A38A1AFDF27C83C /* Pods-EditorDemo-WordPress-iOS-Editor-dummy.m */; };
+		6B401B6756884BB3678D8657 /* DDMultiFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = F1C04F3F3D4AD90EC1CF60C6 /* DDMultiFormatter.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0 -w -Xanalyzer -analyzer-disable-checker -Xanalyzer deadcode"; }; };
+		6C5C08287C868DEB4E2932D9 /* DDFileLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = A23AF990EA8E1465C5EA2792 /* DDFileLogger.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0 -w -Xanalyzer -analyzer-disable-checker -Xanalyzer deadcode"; }; };
+		6DD8D7CC3089C10D28AECDFE /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1715BBEFB6401E99EA712D71 /* Foundation.framework */; };
+		72058F94CD93567431869743 /* Pods-EditorDemo-CocoaLumberjack-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = D433D2E8A688F8A9CAFFB415 /* Pods-EditorDemo-CocoaLumberjack-dummy.m */; };
+		72D231C1EBEEC3937BBD34FE /* Pods-EditorDemo-WordPressCom-Analytics-iOS-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 46F9C8EB1564CC02D7BE58F5 /* Pods-EditorDemo-WordPressCom-Analytics-iOS-dummy.m */; };
+		738F097815FD31FB5AC4BAEB /* CYRLayoutManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 1AB7A659E7CEB4106CF7E4DD /* CYRLayoutManager.m */; };
+		7703B851D7D705B9B4787D67 /* UIActivityIndicatorView+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = 311C6EDA025611DECCA08315 /* UIActivityIndicatorView+AFNetworking.m */; };
+		771B76954B55F7C8431FFEF3 /* Pods-EditorDemoTests-CocoaLumberjack-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = FF915CAFDE4D469F90759FD9 /* Pods-EditorDemoTests-CocoaLumberjack-dummy.m */; };
+		7B0D8D1D91CA6BB393EDCE9B /* DDLegacyMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = C6953FD23C17AD12497FBB0F /* DDLegacyMacros.h */; };
+		7C3B2DC1BC16EC8E9AC1FB2B /* AFURLRequestSerialization.h in Headers */ = {isa = PBXBuildFile; fileRef = 3E468D9FFDAE323AC5151DE2 /* AFURLRequestSerialization.h */; };
+		7D2FA67057C979CB3BD6E1FD /* DDLogMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 18A705C1D1A09576152A5618 /* DDLogMacros.h */; };
+		7EC36CFB9EE037365326488A /* HRColorCursor.m in Sources */ = {isa = PBXBuildFile; fileRef = 76BDC2FCBC2BA88FB97A16C5 /* HRColorCursor.m */; };
+		7ED8086034BA76D220561EAF /* HRColorPickerView.m in Sources */ = {isa = PBXBuildFile; fileRef = 69E26CA56F380BD51A9A5780 /* HRColorPickerView.m */; };
+		7EE576702B238DB4211AB2D4 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1715BBEFB6401E99EA712D71 /* Foundation.framework */; };
+		7F1CCBF721ECF6BFEF54F858 /* UIAlertView+AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = 58A390AA3878ED244AF4145F /* UIAlertView+AFNetworking.h */; };
+		80374557CD2AC2CF8FA81995 /* AFNetworkReachabilityManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 6E8DC67E9E5090F63319260D /* AFNetworkReachabilityManager.h */; };
+		835CFF91BA2C62DD4A6EB222 /* Pods-EditorDemo-NSObject-SafeExpectations-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 372E7D52FF1C08DF33E55661 /* Pods-EditorDemo-NSObject-SafeExpectations-dummy.m */; };
+		849DDC4B8CD6000A8D6FE99C /* AFNetworkActivityIndicatorManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 1A22270E1206E29078682CCB /* AFNetworkActivityIndicatorManager.h */; };
+		859B9CB333C8C7719E6A1C2F /* DDFileLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = B47F30258990ECA0D498A47A /* DDFileLogger.h */; };
+		89499C7156D8394491DD9026 /* ZSSTextView.m in Sources */ = {isa = PBXBuildFile; fileRef = 75C887F2FFC0C86B017A0ADB /* ZSSTextView.m */; };
+		8A2FE5CE1AA54A256029D793 /* DDDispatchQueueLogFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = 77241CD57509022AF218143E /* DDDispatchQueueLogFormatter.h */; };
+		94DEF0859EF39C1B2EA934A8 /* CYRToken.m in Sources */ = {isa = PBXBuildFile; fileRef = 242FC6638990FE497706BE53 /* CYRToken.m */; };
+		96A40BCF7845F397F3ADE371 /* WPTableViewSectionHeaderView.m in Sources */ = {isa = PBXBuildFile; fileRef = 3ED80500DFCEC27F4AE8C221 /* WPTableViewSectionHeaderView.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-checker -Xanalyzer deadcode"; }; };
+		9798C038DC6E903CE3314867 /* DDASLLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = 035B336B3ECB594B6A8A342A /* DDASLLogger.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0 -w -Xanalyzer -analyzer-disable-checker -Xanalyzer deadcode"; }; };
+		9B0D1847DD97F363225C3E38 /* WPAnalytics.h in Headers */ = {isa = PBXBuildFile; fileRef = 89178CA53DE5E6AADB6E2DC8 /* WPAnalytics.h */; };
+		9B3D4B334A933570EDC60F93 /* AFHTTPSessionManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 940F4A009B6C35A94B00B390 /* AFHTTPSessionManager.m */; };
+		9C20D2FCDA2FCE9EA4DA2EE3 /* WPDeviceIdentification.h in Headers */ = {isa = PBXBuildFile; fileRef = C8484604FD3033710AB6DE62 /* WPDeviceIdentification.h */; };
+		9DD2ADC7E5F0F64E2382787C /* AFURLConnectionOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 035D98E3238B5312570CDE80 /* AFURLConnectionOperation.m */; };
+		9EC721EAF6E3189F444E267C /* AFHTTPRequestOperationManager.h in Headers */ = {isa = PBXBuildFile; fileRef = DC187FBCD9C194FA06A35129 /* AFHTTPRequestOperationManager.h */; };
+		9ED2C863083B9955875ABFA5 /* UIImage+Util.m in Sources */ = {isa = PBXBuildFile; fileRef = 36944359AB06987437512C83 /* UIImage+Util.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-checker -Xanalyzer deadcode"; }; };
+		9ED5E2087D695FD07562A2AB /* WPDeviceIdentification.m in Sources */ = {isa = PBXBuildFile; fileRef = A04E1DC754C74A9AFAF22576 /* WPDeviceIdentification.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-checker -Xanalyzer deadcode"; }; };
+		A2184FBCBED6E7DE8602041B /* AFURLConnectionOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 7B4BEB1ED0D87B02894A937B /* AFURLConnectionOperation.h */; };
+		A5DEACDC0E390C8E22988AA0 /* WPTableViewSectionFooterView.h in Headers */ = {isa = PBXBuildFile; fileRef = EE0C32445AB6CD2838D91647 /* WPTableViewSectionFooterView.h */; };
+		A794B130912D80392430668C /* UIWebView+GUIFixes.m in Sources */ = {isa = PBXBuildFile; fileRef = 0F4C1C6D7959E19FE3017BEC /* UIWebView+GUIFixes.m */; };
+		AAB9802A3772474A932F3A58 /* DDContextFilterLogFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = 2E66D244D542F23A3C2B98C2 /* DDContextFilterLogFormatter.h */; };
+		AB7F9ADF6247BFFF16A7C969 /* Merriweather-Italic.otf in Resources */ = {isa = PBXBuildFile; fileRef = E008A051AE16697FBF99938F /* Merriweather-Italic.otf */; };
+		AB9A16BD56C0F4E937442A50 /* OpenSans-BoldItalic.ttf in Resources */ = {isa = PBXBuildFile; fileRef = C55B74F70932078898621BEB /* OpenSans-BoldItalic.ttf */; };
+		ABBF193788F5B8D1EB389F3A /* ZSSBarButtonItem.m in Sources */ = {isa = PBXBuildFile; fileRef = E7E9E00054084C2BD9AE08A6 /* ZSSBarButtonItem.m */; };
+		AC0FCE9CEF54F774867E8968 /* DDASLLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = 035B336B3ECB594B6A8A342A /* DDASLLogger.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0 -w -Xanalyzer -analyzer-disable-checker -Xanalyzer deadcode"; }; };
+		ADC0448276C8890FBB316DAF /* OpenSans-Italic.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 30859BF8628CBD0DE0A5AF66 /* OpenSans-Italic.ttf */; };
+		ADD93F61130631C439990F22 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1715BBEFB6401E99EA712D71 /* Foundation.framework */; };
+		B40E391CF2EE1659974E1B5C /* Pods-EditorDemo-WordPress-iOS-Shared-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = F8856C375E1B9CD7D48506CA /* Pods-EditorDemo-WordPress-iOS-Shared-dummy.m */; };
+		B4FDEB5CE7A422109124CAF4 /* DDContextFilterLogFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = B11EEE44A00709A906D350E0 /* DDContextFilterLogFormatter.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0 -w -Xanalyzer -analyzer-disable-checker -Xanalyzer deadcode"; }; };
+		B50899E9D868142861284800 /* WPEditorField.h in Headers */ = {isa = PBXBuildFile; fileRef = E8A4B42045977FD8F38D2E48 /* WPEditorField.h */; };
+		B6EB43F030B950FA98B7BFC8 /* WPEditorToolbarView.h in Headers */ = {isa = PBXBuildFile; fileRef = EB96F0A45B47C6C5D19988C5 /* WPEditorToolbarView.h */; };
+		B738C45B49188DA699F0677E /* Merriweather-Light.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 5B62FE1DB620BA0F7EC28E47 /* Merriweather-Light.ttf */; };
+		B9C54AF9ED59EBDFA8D20F91 /* WPLegacyKeyboardToolbarDone.h in Headers */ = {isa = PBXBuildFile; fileRef = A6D0FB35913872011A176B84 /* WPLegacyKeyboardToolbarDone.h */; };
+		BCAD3D083F7064A5BDC49F30 /* AFURLSessionManager.m in Sources */ = {isa = PBXBuildFile; fileRef = B422F6762B690B55C1EC79AA /* AFURLSessionManager.m */; };
+		BF4084F7FCAB671A071B4133 /* UIImageView+AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = E3A69BFB86F47ADB12091BB6 /* UIImageView+AFNetworking.h */; };
+		BFCF75B544C536E11F558402 /* ZSSTextView.h in Headers */ = {isa = PBXBuildFile; fileRef = 7681897CF50837832FE2299B /* ZSSTextView.h */; };
+		BFEAECAA34F8A822AE1244F3 /* UIColor+Helpers.h in Headers */ = {isa = PBXBuildFile; fileRef = FD982447098BDC0FF09F9121 /* UIColor+Helpers.h */; };
+		C094E675878FBCED2F6A7076 /* DDMultiFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = F1C04F3F3D4AD90EC1CF60C6 /* DDMultiFormatter.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0 -w -Xanalyzer -analyzer-disable-checker -Xanalyzer deadcode"; }; };
+		C392B2E9DFB97D3E513FA584 /* WPLegacyEditorViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = FCBD9FF897F946CC0EAEAA26 /* WPLegacyEditorViewController.m */; };
+		C3958D8C5D54BC51ABEB1219 /* WPEditorViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 202F5E43C3E3A51610693AD5 /* WPEditorViewController.h */; };
+		C4BD930116AB06713D193C1F /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7F53F9D8EB84F95DEE41E54D /* Security.framework */; };
+		C9690BA45AC64A6EA053D6B2 /* DDAbstractDatabaseLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = 6F9D799883EEAFA57E678C3F /* DDAbstractDatabaseLogger.h */; };
+		C994C49E96A3B63C3FE1B026 /* DDTTYLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = BFF4FBE75092CC85C45662DD /* DDTTYLogger.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0 -w -Xanalyzer -analyzer-disable-checker -Xanalyzer deadcode"; }; };
+		CA4FA5D4995CE106BB783588 /* WPNUXUtility.h in Headers */ = {isa = PBXBuildFile; fileRef = FB6AA4BA7CEA049494551C3D /* WPNUXUtility.h */; };
+		CB220B86C9A81F2C61542528 /* DDMultiFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = 17AFACC2BDB34CFFF477DD38 /* DDMultiFormatter.h */; };
+		CB86C5380139BD15B2D4D23B /* DDASLLogCapture.m in Sources */ = {isa = PBXBuildFile; fileRef = 49950677A0673A43329414AE /* DDASLLogCapture.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0 -w -Xanalyzer -analyzer-disable-checker -Xanalyzer deadcode"; }; };
+		CCCCD1DFA002B0A4BC92FDED /* DDAssertMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = 737A955B6AB464B3A2DEECD7 /* DDAssertMacros.h */; };
+		CCD33E7253FA7F2BC6878677 /* Pods-EditorDemo-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = A202938EC1CAF9A2894E9DD0 /* Pods-EditorDemo-dummy.m */; };
+		D0D3428A3A13E91DCB25C4E1 /* WPLegacyKeyboardToolbarBase.m in Sources */ = {isa = PBXBuildFile; fileRef = 4136FEC8DF0711065CDF11DC /* WPLegacyKeyboardToolbarBase.m */; };
+		D113A979106AFADF3E769DE3 /* WPTableViewSectionHeaderView.h in Headers */ = {isa = PBXBuildFile; fileRef = 6550526B8CFC8CDCE4485C85 /* WPTableViewSectionHeaderView.h */; };
+		D4569EEA542A5AEE4C517DE1 /* UIButton+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = BBA4062FEA14CA197DA5B036 /* UIButton+AFNetworking.m */; };
+		D498B7A31767B32911C03C2F /* WPNUXUtility.m in Sources */ = {isa = PBXBuildFile; fileRef = 34709FADBBDA7A7B1005CD94 /* WPNUXUtility.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-checker -Xanalyzer deadcode"; }; };
+		D542E20CB0FCD6164F17FDE8 /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 042F776A7301B5A6AB041FEC /* SystemConfiguration.framework */; };
+		D62092865CBEA6891A04D871 /* WPNoResultsView.m in Sources */ = {isa = PBXBuildFile; fileRef = 7334EA17018B09751A95A371 /* WPNoResultsView.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-checker -Xanalyzer deadcode"; }; };
+		D6365E613803E1DFEDC0D92F /* DDAbstractDatabaseLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = 18FBB2E8FC94F4DD1F05C44B /* DDAbstractDatabaseLogger.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0 -w -Xanalyzer -analyzer-disable-checker -Xanalyzer deadcode"; }; };
+		D7B1AA9E2C6854631A7C855E /* WPLegacyKeyboardToolbarBase.h in Headers */ = {isa = PBXBuildFile; fileRef = 461E47229FF250FB9C85BDDF /* WPLegacyKeyboardToolbarBase.h */; };
+		D85D7700AE58F528C429F0E4 /* HRCgUtil.h in Headers */ = {isa = PBXBuildFile; fileRef = 4C6F28CA3F79CD33878D4A2A /* HRCgUtil.h */; };
+		D8642EF734E1642582BA0EDF /* AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = 830D29E461F607EF9E618A7D /* AFNetworking.h */; };
+		D928667F03F0873DB5641670 /* UIWebView+GUIFixes.h in Headers */ = {isa = PBXBuildFile; fileRef = B15945148F4AEB9DBDB51856 /* UIWebView+GUIFixes.h */; };
+		D93867AE3D96C055CBEC659A /* AFHTTPRequestOperationManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 37FA504A49AC5684EF946CBD /* AFHTTPRequestOperationManager.m */; };
+		D99ED9DFF4D6CDE4BC89C16D /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1715BBEFB6401E99EA712D71 /* Foundation.framework */; };
+		DDAFFCF0E39BDD97834FB42A /* WPEditorView.h in Headers */ = {isa = PBXBuildFile; fileRef = 23A06DEFC23188E688169C2D /* WPEditorView.h */; };
+		DF7C65731C265AA055158661 /* DDASLLogCapture.h in Headers */ = {isa = PBXBuildFile; fileRef = E7C27BA430080E70025E12CD /* DDASLLogCapture.h */; };
+		E040F2B361B456A9D8D47F22 /* MobileCoreServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 28775F67E478EDD244AE7627 /* MobileCoreServices.framework */; };
+		E04A01ECC56C9FFC260948C5 /* AFSecurityPolicy.m in Sources */ = {isa = PBXBuildFile; fileRef = 2849F0104A3F2D6D00745B1D /* AFSecurityPolicy.m */; };
+		E11133045C1673D188391027 /* CYRTextStorage.m in Sources */ = {isa = PBXBuildFile; fileRef = E0B8D2BA2411BE41144FF737 /* CYRTextStorage.m */; };
+		E14093CAE16763D00984E737 /* HRBrightnessCursor.m in Sources */ = {isa = PBXBuildFile; fileRef = 75E48F1669F5240C37D42CD0 /* HRBrightnessCursor.m */; };
+		E1F43BF89EB0DDD9D8E2C4FC /* CYRTextView.h in Headers */ = {isa = PBXBuildFile; fileRef = B0DA4757DEBA061F8BEA5C90 /* CYRTextView.h */; };
+		E26769B0238C6187391550B6 /* OpenSans-Semibold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 7EBA66A1BD335B70B21AF8D3 /* OpenSans-Semibold.ttf */; };
+		E3FBB9BA5560FC15173A572F /* OpenSans-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = B1A4B03D05F71C61BD430F79 /* OpenSans-Regular.ttf */; };
+		E4A0B7DCE50CB26AF3AE34EB /* UIKit+AFNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = 605D515A3EF49FA9807F52E2 /* UIKit+AFNetworking.h */; };
+		E57E5C98ACF180B75B54AE74 /* HRCgUtil.m in Sources */ = {isa = PBXBuildFile; fileRef = 5014F8280E10445967428D5E /* HRCgUtil.m */; };
+		E5E8212F6255A8FB06902F8A /* WPFontManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 7CB2348B9191FFBAF446C505 /* WPFontManager.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-checker -Xanalyzer deadcode"; }; };
+		E61E58E633BE54390F5DA65F /* WPImageSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 43E12506949E3528076FD742 /* WPImageSource.h */; };
+		E6EB119A582FDF2C8991D340 /* OpenSans-Light.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 184CDEC9AEEA4AB4456EE297 /* OpenSans-Light.ttf */; };
+		E6ECBF0772F8DDB8474EEE7C /* NSString+XMLExtensions.h in Headers */ = {isa = PBXBuildFile; fileRef = E523C7CAD67485E52A339467 /* NSString+XMLExtensions.h */; };
+		EAC0B7519D7B44AA998F14CC /* WPTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 39A6D2B1D31F514BE1BCB543 /* WPTableViewCell.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-checker -Xanalyzer deadcode"; }; };
+		EB5E82185FDED2D30B1E0502 /* UIRefreshControl+AFNetworking.m in Sources */ = {isa = PBXBuildFile; fileRef = 4C42ED855F0AE2EDAA16A5D8 /* UIRefreshControl+AFNetworking.m */; };
+		EE89C9B73413E7BF784DEC81 /* DDFileLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = A23AF990EA8E1465C5EA2792 /* DDFileLogger.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0 -w -Xanalyzer -analyzer-disable-checker -Xanalyzer deadcode"; }; };
+		EE8D321D67823174062BF49C /* Pods-EditorDemo-AFNetworking-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = A8AE6EAD9DC1D6E0427A7141 /* Pods-EditorDemo-AFNetworking-dummy.m */; };
+		F1F002C96F141C844E260262 /* DDASLLogCapture.h in Headers */ = {isa = PBXBuildFile; fileRef = E7C27BA430080E70025E12CD /* DDASLLogCapture.h */; };
+		F47FBBA60C955096F308DC1F /* WPTableViewCell.h in Headers */ = {isa = PBXBuildFile; fileRef = 8D2907D3E03FDD35B890C6EB /* WPTableViewCell.h */; };
+		F69056803DF594FB65E4A179 /* Merriweather-LightItalic.otf in Resources */ = {isa = PBXBuildFile; fileRef = 4C86F7989DFF3E0ACF0B5353 /* Merriweather-LightItalic.otf */; };
+		F73A073A4D07BDF43E4026D9 /* UIColor+Helpers.m in Sources */ = {isa = PBXBuildFile; fileRef = 01B925E4371AA877422D1B0E /* UIColor+Helpers.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-checker -Xanalyzer deadcode"; }; };
+		FAC5096955D6B4D1DDD7777B /* AFNetworkReachabilityManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 7E40A3436DCC6C41C855EF10 /* AFNetworkReachabilityManager.m */; };
+		FC6EB64BC6B9D6DE07721D15 /* WPEditorView.m in Sources */ = {isa = PBXBuildFile; fileRef = 420D65E0EAB5DFA8861D01FB /* WPEditorView.m */; };
+		FD79394D3DD06D07D67DAE21 /* CYRTextStorage.h in Headers */ = {isa = PBXBuildFile; fileRef = FE3F9F6081F04307C5F8F75C /* CYRTextStorage.h */; };
+		FF7402E0AA556400A209D3B0 /* Merriweather-Bold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 44DC9BF94D0FCA6892703CC3 /* Merriweather-Bold.ttf */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		053B8D1CD06E60242068CC6A /* PBXContainerItemProxy */ = {
+		048D67368EA22641BE75D0E1 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = 8271F7CE20E8F531623E8A97 /* Project object */;
+			containerPortal = F0816A4D6FC502289658307E /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = BEE2D6A907D7AB7A9244F7C1;
-			remoteInfo = "Pods-EditorDemo-AFNetworking";
-		};
-		4A57ECF9385D63F93D59F1DE /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 8271F7CE20E8F531623E8A97 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 5B5431C7C77BA40377BC1687;
-			remoteInfo = "Pods-EditorDemo-WordPress-iOS-Shared";
-		};
-		5D11850C6C3489B42A6BF181 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 8271F7CE20E8F531623E8A97 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = FA5FD4A9C080E0761D062744;
-			remoteInfo = "Pods-EditorDemo-NSObject-SafeExpectations";
-		};
-		63764D97FD738E04AFC2D702 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 8271F7CE20E8F531623E8A97 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = EF66BE9BB75DDC0CAF93A2A4;
-			remoteInfo = "Pods-EditorDemo-CocoaLumberjack";
-		};
-		6C91A6744405BA24C0BF4C5F /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 8271F7CE20E8F531623E8A97 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = FA5FD4A9C080E0761D062744;
-			remoteInfo = "Pods-EditorDemo-NSObject-SafeExpectations";
-		};
-		718AA23BC316C48D8AAA40CE /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 8271F7CE20E8F531623E8A97 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 684969EABA68BEADF10760C6;
+			remoteGlobalIDString = 8076187268BA2E5AC117B39D;
 			remoteInfo = "Pods-EditorDemo-UIAlertView+Blocks";
 		};
-		7A1FED650D23667E449449B7 /* PBXContainerItemProxy */ = {
+		099571317EB7E73D1DA765FE /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = 8271F7CE20E8F531623E8A97 /* Project object */;
+			containerPortal = F0816A4D6FC502289658307E /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = EF66BE9BB75DDC0CAF93A2A4;
-			remoteInfo = "Pods-EditorDemo-CocoaLumberjack";
+			remoteGlobalIDString = D3A798B2F3EC4A44BB808D7D;
+			remoteInfo = "Pods-EditorDemo-WordPress-iOS-Shared";
 		};
-		81F7F26651C0D81E2B15B038 /* PBXContainerItemProxy */ = {
+		0DE906DA61146424585F8EB6 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = 8271F7CE20E8F531623E8A97 /* Project object */;
+			containerPortal = F0816A4D6FC502289658307E /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = EF66BE9BB75DDC0CAF93A2A4;
-			remoteInfo = "Pods-EditorDemo-CocoaLumberjack";
-		};
-		84EDBCD06B0D00DD3210EBBD /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 8271F7CE20E8F531623E8A97 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = F735F3AFF58FF4215065D9F1;
+			remoteGlobalIDString = 2DF9E43CC1FCA5E4B490292F;
 			remoteInfo = "Pods-EditorDemo-WordPress-iOS-Editor";
 		};
-		A2E098CB2A146E80D28F23AE /* PBXContainerItemProxy */ = {
+		20EA7ED7C6B5706503E2F326 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = 8271F7CE20E8F531623E8A97 /* Project object */;
+			containerPortal = F0816A4D6FC502289658307E /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = F9232E0662913FFA323EABC0;
+			remoteGlobalIDString = 0393028516D354A9A4D3EF99;
+			remoteInfo = "Pods-EditorDemo-NSObject-SafeExpectations";
+		};
+		2888BB7333BE006076904727 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = F0816A4D6FC502289658307E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 15B586F6C561CD73D6ECF2B9;
 			remoteInfo = "Pods-EditorDemoTests-CocoaLumberjack";
 		};
-		A64853A751234EEB2C81D70B /* PBXContainerItemProxy */ = {
+		3145E228AD71D0966CA32BCD /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = 8271F7CE20E8F531623E8A97 /* Project object */;
+			containerPortal = F0816A4D6FC502289658307E /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 7F986800EA7C868765DE35F0;
+			remoteGlobalIDString = 5E6D10BB217E7B786F5D79C0;
 			remoteInfo = "Pods-EditorDemo-WordPressCom-Analytics-iOS";
 		};
-		A70F164E374D980AE4E04010 /* PBXContainerItemProxy */ = {
+		347DFA422F3B9A90E0FE68C2 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = 8271F7CE20E8F531623E8A97 /* Project object */;
+			containerPortal = F0816A4D6FC502289658307E /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 7F986800EA7C868765DE35F0;
+			remoteGlobalIDString = D3A798B2F3EC4A44BB808D7D;
+			remoteInfo = "Pods-EditorDemo-WordPress-iOS-Shared";
+		};
+		6A8D9861EA93060C17ADB3D2 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = F0816A4D6FC502289658307E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 5E6D10BB217E7B786F5D79C0;
 			remoteInfo = "Pods-EditorDemo-WordPressCom-Analytics-iOS";
 		};
-		C137F8925FAE86F0A5B5FC4A /* PBXContainerItemProxy */ = {
+		6B331479DABD27D68472575B /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = 8271F7CE20E8F531623E8A97 /* Project object */;
+			containerPortal = F0816A4D6FC502289658307E /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = EA9587BFD26F177B278CAAC5;
-			remoteInfo = "Pods-EditorDemo-WordPress-iOS-Shared-WordPress-iOS-Shared";
-		};
-		CBB2E5A4E9C59F02C6090D14 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 8271F7CE20E8F531623E8A97 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 684969EABA68BEADF10760C6;
-			remoteInfo = "Pods-EditorDemo-UIAlertView+Blocks";
-		};
-		DBFED12E6E17D5DAC10C6C62 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 8271F7CE20E8F531623E8A97 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = BEE2D6A907D7AB7A9244F7C1;
+			remoteGlobalIDString = 14DA1C38BD897A55BC7C57E0;
 			remoteInfo = "Pods-EditorDemo-AFNetworking";
 		};
-		E83E4AB92E6CCE8CC3ECF25E /* PBXContainerItemProxy */ = {
+		6F45910311E7BA4B869E3C21 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = 8271F7CE20E8F531623E8A97 /* Project object */;
+			containerPortal = F0816A4D6FC502289658307E /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 5B5431C7C77BA40377BC1687;
-			remoteInfo = "Pods-EditorDemo-WordPress-iOS-Shared";
+			remoteGlobalIDString = 0393028516D354A9A4D3EF99;
+			remoteInfo = "Pods-EditorDemo-NSObject-SafeExpectations";
+		};
+		7289541ACD672ED649281BA3 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = F0816A4D6FC502289658307E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 14DA1C38BD897A55BC7C57E0;
+			remoteInfo = "Pods-EditorDemo-AFNetworking";
+		};
+		915781B0DE1C151111238425 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = F0816A4D6FC502289658307E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = BEE097ACE07B5200E2FD2A7E;
+			remoteInfo = "Pods-EditorDemo-CocoaLumberjack";
+		};
+		988616CC35C8E4BAC72ADC00 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = F0816A4D6FC502289658307E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = F943581E7E73994D03920816;
+			remoteInfo = "Pods-EditorDemo-WordPress-iOS-Shared-WordPress-iOS-Shared";
+		};
+		D59C9306379C634A6B929CDB /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = F0816A4D6FC502289658307E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = BEE097ACE07B5200E2FD2A7E;
+			remoteInfo = "Pods-EditorDemo-CocoaLumberjack";
+		};
+		D81BB86992BEF6A4742C4C0E /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = F0816A4D6FC502289658307E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = BEE097ACE07B5200E2FD2A7E;
+			remoteInfo = "Pods-EditorDemo-CocoaLumberjack";
+		};
+		FA6A4B32327C8DA6C1A3F33F /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = F0816A4D6FC502289658307E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 8076187268BA2E5AC117B39D;
+			remoteInfo = "Pods-EditorDemo-UIAlertView+Blocks";
 		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		0111805967E885663F108E64 /* icon_format_link@2x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = "icon_format_link@2x.png"; sourceTree = "<group>"; };
-		018979C89C385724745283B5 /* UIAlertView+Blocks.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "UIAlertView+Blocks.h"; sourceTree = "<group>"; };
-		018FA367567DFEC4AD1F893F /* WPLegacyKeyboardToolbarBase.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = WPLegacyKeyboardToolbarBase.m; sourceTree = "<group>"; };
-		01D2A5EF4B44A19D2FB56234 /* icon_format_unlink@2x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = "icon_format_unlink@2x.png"; sourceTree = "<group>"; };
-		02CB79961772C1D3C1C0B32F /* libPods-EditorDemo-AFNetworking.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-EditorDemo-AFNetworking.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		03307AB3857022B32EA286FF /* UIProgressView+AFNetworking.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIProgressView+AFNetworking.h"; path = "UIKit+AFNetworking/UIProgressView+AFNetworking.h"; sourceTree = "<group>"; };
-		03D7B2AC28815C9E1902F30C /* ZSSh5.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = ZSSh5.png; sourceTree = "<group>"; };
-		045EDAFF2CA6C9E03F1A9EFE /* DDDispatchQueueLogFormatter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = DDDispatchQueueLogFormatter.h; path = Classes/Extensions/DDDispatchQueueLogFormatter.h; sourceTree = "<group>"; };
-		04657334CF1393C9DA45499B /* ZSSbgcolor.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = ZSSbgcolor.png; sourceTree = "<group>"; };
-		04FA2B1AA8B4A5E188F32C2F /* WordPress-iOS-Shared.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "WordPress-iOS-Shared.bundle"; sourceTree = BUILT_PRODUCTS_DIR; };
-		056879325A78CF12075A1053 /* Merriweather-Bold.ttf */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = file; name = "Merriweather-Bold.ttf"; path = "WordPress-iOS-Shared/Assets/Merriweather-Bold.ttf"; sourceTree = "<group>"; };
-		05C8E2635437A1E8EBB28608 /* icon_format_media@2x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = "icon_format_media@2x.png"; sourceTree = "<group>"; };
-		060F276754F0350A2FA05117 /* Merriweather-BoldItalic.otf */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = file; name = "Merriweather-BoldItalic.otf"; path = "WordPress-iOS-Shared/Assets/Merriweather-BoldItalic.otf"; sourceTree = "<group>"; };
-		081D050556EF0814FE87552A /* ZSSh6.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = ZSSh6.png; sourceTree = "<group>"; };
-		0840F86DFF61C244FAD606BA /* ZSSh6@2x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = "ZSSh6@2x.png"; sourceTree = "<group>"; };
-		091546E15BC3F0E725600780 /* WPAnimatedImageResponseSerializer.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = WPAnimatedImageResponseSerializer.h; path = "WordPress-iOS-Shared/Core/WPAnimatedImageResponseSerializer.h"; sourceTree = "<group>"; };
-		09D1BCFC1F4E975478078E92 /* WPTableViewCell.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = WPTableViewCell.m; path = "WordPress-iOS-Shared/Core/WPTableViewCell.m"; sourceTree = "<group>"; };
-		0A7931B903B64940FDB91BCA /* icon_format_italic.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = icon_format_italic.png; sourceTree = "<group>"; };
-		0AD31CA003EF27F7E0FF2846 /* Pods-EditorDemoTests-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-EditorDemoTests-acknowledgements.plist"; sourceTree = "<group>"; };
-		0AE80F9D135E74992FBF0F68 /* WPStyleGuide.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = WPStyleGuide.m; path = "WordPress-iOS-Shared/Core/WPStyleGuide.m"; sourceTree = "<group>"; };
-		0D0C7128CE5F7BD365035E58 /* ZSScenterjustify.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = ZSScenterjustify.png; sourceTree = "<group>"; };
-		0DB2B67BABFAF4ED3D2ECB51 /* DDContextFilterLogFormatter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = DDContextFilterLogFormatter.m; path = Classes/Extensions/DDContextFilterLogFormatter.m; sourceTree = "<group>"; };
-		0FD2B36D886DFC8099841A0B /* WPLegacyKeyboardToolbarBase.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = WPLegacyKeyboardToolbarBase.h; sourceTree = "<group>"; };
-		112CC384C22A5E4734216238 /* UIImage+Util.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIImage+Util.h"; path = "WordPress-iOS-Shared/Core/UIImage+Util.h"; sourceTree = "<group>"; };
-		1232CFE2F61607CF8870E363 /* Pods-EditorDemo-NSObject-SafeExpectations-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-EditorDemo-NSObject-SafeExpectations-dummy.m"; sourceTree = "<group>"; };
-		1350BA0F996FFA831EED6BEB /* DDTTYLogger.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = DDTTYLogger.m; path = Classes/DDTTYLogger.m; sourceTree = "<group>"; };
-		13B9F5A3DB671D9E4E786139 /* Pods-EditorDemoTests-CocoaLumberjack.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-EditorDemoTests-CocoaLumberjack.xcconfig"; path = "../Pods-EditorDemoTests-CocoaLumberjack/Pods-EditorDemoTests-CocoaLumberjack.xcconfig"; sourceTree = "<group>"; };
-		14F28812D5D2F11A0E018098 /* UIColor+Helpers.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIColor+Helpers.m"; path = "WordPress-iOS-Shared/Core/UIColor+Helpers.m"; sourceTree = "<group>"; };
-		15C3EB7321BB804FBCCC2B5B /* ZSScenterjustify@2x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = "ZSScenterjustify@2x.png"; sourceTree = "<group>"; };
-		15C935CB95046392FA40871B /* icon_format_ol@3x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = "icon_format_ol@3x.png"; sourceTree = "<group>"; };
-		176C9DE7D881606395EE8288 /* NSDictionary+SafeExpectations.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "NSDictionary+SafeExpectations.h"; sourceTree = "<group>"; };
-		17A14C852C9344ACAE60A163 /* WPAnimatedImageResponseSerializer.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = WPAnimatedImageResponseSerializer.m; path = "WordPress-iOS-Shared/Core/WPAnimatedImageResponseSerializer.m"; sourceTree = "<group>"; };
-		1A9E846D20EEEA4C182CDFB5 /* libPods-EditorDemo-WordPressCom-Analytics-iOS.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-EditorDemo-WordPressCom-Analytics-iOS.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		1ACB5D3CD0353F368F0C28A2 /* Pods-EditorDemo-WordPress-iOS-Editor-Private.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-EditorDemo-WordPress-iOS-Editor-Private.xcconfig"; sourceTree = "<group>"; };
-		1B42E8DEA5EED6E7D484E62D /* WPTableViewSectionFooterView.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = WPTableViewSectionFooterView.m; path = "WordPress-iOS-Shared/Core/WPTableViewSectionFooterView.m"; sourceTree = "<group>"; };
-		1BB5DD4596CB66A5A3FCB618 /* libPods-EditorDemo-NSObject-SafeExpectations.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-EditorDemo-NSObject-SafeExpectations.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		1D176147CF7DAE7F8D372DF5 /* libPods-EditorDemo-WordPress-iOS-Shared.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-EditorDemo-WordPress-iOS-Shared.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		1D4D5A88C0F26EFC90814CB1 /* Merriweather-Regular.ttf */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = file; name = "Merriweather-Regular.ttf"; path = "WordPress-iOS-Shared/Assets/Merriweather-Regular.ttf"; sourceTree = "<group>"; };
-		1D4D93A62C39721D8A512F8F /* HRCgUtil.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = HRCgUtil.h; sourceTree = "<group>"; };
-		1DBF976142E1D7C7799DD0F9 /* WPNoResultsView.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = WPNoResultsView.m; path = "WordPress-iOS-Shared/Core/WPNoResultsView.m"; sourceTree = "<group>"; };
-		1DF3E84B7B3532517590657B /* WPNUXUtility.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = WPNUXUtility.h; path = "WordPress-iOS-Shared/Core/WPNUXUtility.h"; sourceTree = "<group>"; };
-		1E5D8ED20A690A5DA0A2E877 /* AFNetworkActivityIndicatorManager.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AFNetworkActivityIndicatorManager.m; path = "UIKit+AFNetworking/AFNetworkActivityIndicatorManager.m"; sourceTree = "<group>"; };
-		1EA7E5C8BFE068046ABEDF8B /* icon_format_bold@2x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = "icon_format_bold@2x.png"; sourceTree = "<group>"; };
-		22CAAD3B6A1A315A25DDAC72 /* WPFontManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = WPFontManager.h; path = "WordPress-iOS-Shared/Core/WPFontManager.h"; sourceTree = "<group>"; };
-		24219DFBC8B4BA641480C086 /* ZSSquicklink@2x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = "ZSSquicklink@2x.png"; sourceTree = "<group>"; };
-		2446A8148FA3150F669D6A7B /* Pods-EditorDemoTests-CocoaLumberjack-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "Pods-EditorDemoTests-CocoaLumberjack-prefix.pch"; path = "../Pods-EditorDemoTests-CocoaLumberjack/Pods-EditorDemoTests-CocoaLumberjack-prefix.pch"; sourceTree = "<group>"; };
-		258129337B6C3AC311D01813 /* Podfile */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
-		26DB64B02A6FE7131DF630E1 /* Pods-EditorDemo-environment.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-EditorDemo-environment.h"; sourceTree = "<group>"; };
-		26E373A57F6558BBFBDC1667 /* OpenSans-Italic.ttf */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = file; name = "OpenSans-Italic.ttf"; path = "WordPress-iOS-Shared/Assets/OpenSans-Italic.ttf"; sourceTree = "<group>"; };
-		280FCC792BA9A1849E28B5E3 /* CYRTextView.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = CYRTextView.m; sourceTree = "<group>"; };
-		284390BBC552E83AAEA885A3 /* OpenSans-Light.ttf */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = file; name = "OpenSans-Light.ttf"; path = "WordPress-iOS-Shared/Assets/OpenSans-Light.ttf"; sourceTree = "<group>"; };
-		295202BE94C845BA62D71F35 /* icon_format_html@3x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = "icon_format_html@3x.png"; sourceTree = "<group>"; };
-		29A69F5003A385EC9CE4B43E /* icon_format_more@2x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = "icon_format_more@2x.png"; sourceTree = "<group>"; };
-		29AC6869AD6DAC9D9CAC15AF /* ZSSsuperscript@2x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = "ZSSsuperscript@2x.png"; sourceTree = "<group>"; };
-		2ADA3E08D958D207EAE97E57 /* icon-posts-editor-inspector@2x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = "icon-posts-editor-inspector@2x.png"; sourceTree = "<group>"; };
-		2AF247072D334D8C21A3B339 /* WPTableViewSectionHeaderView.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = WPTableViewSectionHeaderView.m; path = "WordPress-iOS-Shared/Core/WPTableViewSectionHeaderView.m"; sourceTree = "<group>"; };
-		2BB0FEADE5DDFD462933EC4D /* Pods-EditorDemo-NSObject-SafeExpectations-Private.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-EditorDemo-NSObject-SafeExpectations-Private.xcconfig"; sourceTree = "<group>"; };
-		2C70C2404F595B1F9EE8479B /* Pods-EditorDemo-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-EditorDemo-acknowledgements.plist"; sourceTree = "<group>"; };
-		2DEADA5A140D78363802CF2D /* icon_format_unlink.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = icon_format_unlink.png; sourceTree = "<group>"; };
-		2F19287E9473481526024216 /* Pods-EditorDemo-AFNetworking-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-EditorDemo-AFNetworking-prefix.pch"; sourceTree = "<group>"; };
-		2F99BB982CA76B351FD5E532 /* UIRefreshControl+AFNetworking.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIRefreshControl+AFNetworking.m"; path = "UIKit+AFNetworking/UIRefreshControl+AFNetworking.m"; sourceTree = "<group>"; };
-		308AB52F92CBCF1CA62FEBCB /* UIKit+AFNetworking.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIKit+AFNetworking.h"; path = "UIKit+AFNetworking/UIKit+AFNetworking.h"; sourceTree = "<group>"; };
-		310C01090D1A63E9DA5240B6 /* DDFileLogger.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = DDFileLogger.h; path = Classes/DDFileLogger.h; sourceTree = "<group>"; };
-		317C00A0F2D55B4BFD06B22E /* HRColorPickerView.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = HRColorPickerView.h; sourceTree = "<group>"; };
-		327E6EC8D455841FD0FBEFE8 /* Merriweather-Italic.otf */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = file; name = "Merriweather-Italic.otf"; path = "WordPress-iOS-Shared/Assets/Merriweather-Italic.otf"; sourceTree = "<group>"; };
-		32D8AB3CB6135FD5386CB9AE /* ZSSh3@2x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = "ZSSh3@2x.png"; sourceTree = "<group>"; };
-		3374B7EF94C885A05367678A /* jquery.js */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.javascript; path = jquery.js; sourceTree = "<group>"; };
-		33A35730DA4CEBC0A9093099 /* icon_format_italic@3x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = "icon_format_italic@3x.png"; sourceTree = "<group>"; };
-		34A701B8110E840B28A9D42B /* CYRTextView.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = CYRTextView.h; sourceTree = "<group>"; };
-		34ED3705F34F9E0B11228A4D /* AFURLConnectionOperation.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AFURLConnectionOperation.h; path = AFNetworking/AFURLConnectionOperation.h; sourceTree = "<group>"; };
-		37AEC98F2495EC75AFBE14FC /* AFURLRequestSerialization.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AFURLRequestSerialization.m; path = AFNetworking/AFURLRequestSerialization.m; sourceTree = "<group>"; };
-		3ACB4A9A875522B4D969989F /* libPods-EditorDemoTests-CocoaLumberjack.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-EditorDemoTests-CocoaLumberjack.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		3ACCAC699D9B945C6C36B45F /* WPEditorToolbarButton.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = WPEditorToolbarButton.h; sourceTree = "<group>"; };
-		3AF37D46D87DE32A97B5232F /* ZSSh4@2x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = "ZSSh4@2x.png"; sourceTree = "<group>"; };
-		3B1A061BB4FE2A39D9878512 /* icon_format_link@3x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = "icon_format_link@3x.png"; sourceTree = "<group>"; };
-		3B1C3F20480ED33CD9AAD28F /* icon_options.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = icon_options.png; sourceTree = "<group>"; };
-		3B5573793DECA2290AFBAA22 /* NSString+XMLExtensions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSString+XMLExtensions.h"; path = "WordPress-iOS-Shared/Core/NSString+XMLExtensions.h"; sourceTree = "<group>"; };
-		3BA661786D95821487D4AE8F /* UIAlertView+Blocks.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "UIAlertView+Blocks.m"; sourceTree = "<group>"; };
-		3C174C35F65ABD415D6A6912 /* icon_preview@2x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = "icon_preview@2x.png"; sourceTree = "<group>"; };
-		3CDF9ED71C9C92EC63F6BFBE /* OpenSans-Semibold.ttf */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = file; name = "OpenSans-Semibold.ttf"; path = "WordPress-iOS-Shared/Assets/OpenSans-Semibold.ttf"; sourceTree = "<group>"; };
-		3D8617C47E04FF8DDCA9AC70 /* icon_format_html.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = icon_format_html.png; sourceTree = "<group>"; };
-		3DF5463DDA4D731C6A03FB50 /* DDASLLogCapture.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = DDASLLogCapture.h; path = Classes/DDASLLogCapture.h; sourceTree = "<group>"; };
-		3DFF8FE68DF9DA0E3299D664 /* UIAlertView+AFNetworking.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIAlertView+AFNetworking.m"; path = "UIKit+AFNetworking/UIAlertView+AFNetworking.m"; sourceTree = "<group>"; };
-		3FC1398D73E29D508B0A6EF7 /* WPHybridCallbacker.js */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.javascript; path = WPHybridCallbacker.js; sourceTree = "<group>"; };
-		3FC1EFEC6EB6188975226AC3 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS8.3.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
-		41CF213A50AFA329F1E34BE4 /* icon_format_quote@3x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = "icon_format_quote@3x.png"; sourceTree = "<group>"; };
-		433ED554028EF4893CAB653F /* UIRefreshControl+AFNetworking.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIRefreshControl+AFNetworking.h"; path = "UIKit+AFNetworking/UIRefreshControl+AFNetworking.h"; sourceTree = "<group>"; };
-		4405DA15440A4795151956A8 /* Pods-EditorDemo-UIAlertView+Blocks-Private.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-EditorDemo-UIAlertView+Blocks-Private.xcconfig"; sourceTree = "<group>"; };
-		45A33659A19AEADBA1C4E30E /* ZSSbgcolor@2x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = "ZSSbgcolor@2x.png"; sourceTree = "<group>"; };
-		45F7A08C76F84BCB288E202F /* libPods-EditorDemo-UIAlertView+Blocks.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-EditorDemo-UIAlertView+Blocks.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		465DB5D3F074B688102F64FC /* icon_format_more@3x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = "icon_format_more@3x.png"; sourceTree = "<group>"; };
-		47A628B62C503D38F07D5D22 /* Pods-EditorDemo-WordPress-iOS-Shared-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-EditorDemo-WordPress-iOS-Shared-dummy.m"; sourceTree = "<group>"; };
-		47CF243D1E5DAB7CF03588E9 /* ZSSTextView.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = ZSSTextView.h; sourceTree = "<group>"; };
-		49DDA0785FC0D8EC2BFED5EE /* ZSStextcolor.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = ZSStextcolor.png; sourceTree = "<group>"; };
-		4B0E4C244D73BA1DBC57A3ED /* AFHTTPRequestOperationManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AFHTTPRequestOperationManager.h; path = AFNetworking/AFHTTPRequestOperationManager.h; sourceTree = "<group>"; };
-		4B28F424A4945347088E67AA /* UIImageView+AFNetworking.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIImageView+AFNetworking.h"; path = "UIKit+AFNetworking/UIImageView+AFNetworking.h"; sourceTree = "<group>"; };
-		4C1A99A1ED8BB763DDCF154F /* OpenSans-SemiboldItalic.ttf */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = file; name = "OpenSans-SemiboldItalic.ttf"; path = "WordPress-iOS-Shared/Assets/OpenSans-SemiboldItalic.ttf"; sourceTree = "<group>"; };
-		4DAD4EFB895576377C6D6421 /* Pods-EditorDemo-WordPressCom-Analytics-iOS-Private.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-EditorDemo-WordPressCom-Analytics-iOS-Private.xcconfig"; sourceTree = "<group>"; };
-		4DEC78BFB5E2A6FAB2E62A8D /* rangy-classapplier.js */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.javascript; path = "rangy-classapplier.js"; sourceTree = "<group>"; };
-		4F1F77A475B60B38DC24BA0D /* ZSSh1@2x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = "ZSSh1@2x.png"; sourceTree = "<group>"; };
-		4F4BA5D091BECE219AC5EF57 /* Pods-EditorDemo-CocoaLumberjack-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-EditorDemo-CocoaLumberjack-prefix.pch"; sourceTree = "<group>"; };
-		5095C5D647072E0857D03F13 /* js-beautifier.js */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.javascript; path = "js-beautifier.js"; sourceTree = "<group>"; };
-		50BDDF1CB570638BB655698E /* wpposter.svg */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xml; path = wpposter.svg; sourceTree = "<group>"; };
-		51DCE8D262D072511132F17B /* Pods-EditorDemo-NSObject-SafeExpectations-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-EditorDemo-NSObject-SafeExpectations-prefix.pch"; sourceTree = "<group>"; };
-		52AD4EC065836A821A33C0DA /* UIWebView+AFNetworking.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIWebView+AFNetworking.h"; path = "UIKit+AFNetworking/UIWebView+AFNetworking.h"; sourceTree = "<group>"; };
-		52ED6F51521BD3D073AD7AD4 /* UIButton+AFNetworking.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIButton+AFNetworking.h"; path = "UIKit+AFNetworking/UIButton+AFNetworking.h"; sourceTree = "<group>"; };
-		54676799AFC754686D4A4FEA /* DDASLLogCapture.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = DDASLLogCapture.m; path = Classes/DDASLLogCapture.m; sourceTree = "<group>"; };
-		55D9883308BCDF32781C842C /* DDLegacyMacros.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = DDLegacyMacros.h; path = Classes/DDLegacyMacros.h; sourceTree = "<group>"; };
-		55DF2E3BACB825D7471A8FEC /* WPEditorToolbarView.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = WPEditorToolbarView.m; sourceTree = "<group>"; };
-		56E3A2813DD6D93629C0FD63 /* WPStyleGuide.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = WPStyleGuide.h; path = "WordPress-iOS-Shared/Core/WPStyleGuide.h"; sourceTree = "<group>"; };
-		588DC83FD71E5DC28532E420 /* Pods-EditorDemo-UIAlertView+Blocks-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-EditorDemo-UIAlertView+Blocks-dummy.m"; sourceTree = "<group>"; };
-		59050B4B96496DFD8DD03035 /* Pods-EditorDemoTests-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-EditorDemoTests-dummy.m"; sourceTree = "<group>"; };
-		59BCCAA21F5127D63C97A477 /* Pods-EditorDemo-AFNetworking-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-EditorDemo-AFNetworking-dummy.m"; sourceTree = "<group>"; };
-		5A018DAB5EDC244F76FF62EF /* Pods-EditorDemo-WordPressCom-Analytics-iOS.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-EditorDemo-WordPressCom-Analytics-iOS.xcconfig"; sourceTree = "<group>"; };
-		5A5291133F8F6D24122120CE /* MobileCoreServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MobileCoreServices.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS8.3.sdk/System/Library/Frameworks/MobileCoreServices.framework; sourceTree = DEVELOPER_DIR; };
-		5A8549A279C4AFD919B26398 /* Pods-EditorDemoTests-CocoaLumberjack-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "Pods-EditorDemoTests-CocoaLumberjack-dummy.m"; path = "../Pods-EditorDemoTests-CocoaLumberjack/Pods-EditorDemoTests-CocoaLumberjack-dummy.m"; sourceTree = "<group>"; };
-		5C7240FA870002C3B38EB209 /* AFHTTPRequestOperation.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AFHTTPRequestOperation.h; path = AFNetworking/AFHTTPRequestOperation.h; sourceTree = "<group>"; };
-		5CAB8FFF0FAB266A65259BCE /* icon_preview.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = icon_preview.png; sourceTree = "<group>"; };
-		5D4410C08BCC867F603078B4 /* DDContextFilterLogFormatter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = DDContextFilterLogFormatter.h; path = Classes/Extensions/DDContextFilterLogFormatter.h; sourceTree = "<group>"; };
-		5D7B8551C93EAA0D264D2B5F /* Pods-EditorDemoTests-environment.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-EditorDemoTests-environment.h"; sourceTree = "<group>"; };
-		5EBFEFC4FE2E8C391CADB7E2 /* icon_format_ul@3x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = "icon_format_ul@3x.png"; sourceTree = "<group>"; };
-		5F85D8AA92A66EF2E1DDA8E9 /* Pods-EditorDemoTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-EditorDemoTests.debug.xcconfig"; sourceTree = "<group>"; };
-		5FF4850648720959CE971516 /* rangy-textrange.js */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.javascript; path = "rangy-textrange.js"; sourceTree = "<group>"; };
-		60160A647A4C6DA0086E5409 /* libPods-EditorDemo-CocoaLumberjack.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-EditorDemo-CocoaLumberjack.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		6079A708C4A86F4C245E9F4F /* Pods-EditorDemo-UIAlertView+Blocks-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-EditorDemo-UIAlertView+Blocks-prefix.pch"; sourceTree = "<group>"; };
-		6083D30E6BF8EE9DDBB17DAB /* ZSSleftjustify@2x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = "ZSSleftjustify@2x.png"; sourceTree = "<group>"; };
-		62A6F5B4248EC25962376F67 /* UIAlertView+AFNetworking.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIAlertView+AFNetworking.h"; path = "UIKit+AFNetworking/UIAlertView+AFNetworking.h"; sourceTree = "<group>"; };
-		62FDA82F50D9AB1BF1110A0B /* WPImageSource.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = WPImageSource.h; path = "WordPress-iOS-Shared/Core/WPImageSource.h"; sourceTree = "<group>"; };
-		63CE022F0C388C12A4764049 /* ZSSclearstyle.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = ZSSclearstyle.png; sourceTree = "<group>"; };
-		66CB0A484B346F4A872A79AE /* Pods-EditorDemoTests-CocoaLumberjack-Private.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-EditorDemoTests-CocoaLumberjack-Private.xcconfig"; path = "../Pods-EditorDemoTests-CocoaLumberjack/Pods-EditorDemoTests-CocoaLumberjack-Private.xcconfig"; sourceTree = "<group>"; };
-		68591B6C1D914577D1E61C9C /* libPods-EditorDemo.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-EditorDemo.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		68863BCB654EC023916826BD /* OpenSans-Bold.ttf */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = file; name = "OpenSans-Bold.ttf"; path = "WordPress-iOS-Shared/Assets/OpenSans-Bold.ttf"; sourceTree = "<group>"; };
-		6893DCC647C2B6A10590134B /* OpenSans-Regular.ttf */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = file; name = "OpenSans-Regular.ttf"; path = "WordPress-iOS-Shared/Assets/OpenSans-Regular.ttf"; sourceTree = "<group>"; };
-		6982929B5675E5E426B55CAD /* icon_format_ol@2x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = "icon_format_ol@2x.png"; sourceTree = "<group>"; };
-		699BDF7BAED524F26D0C67D3 /* Pods-EditorDemo-WordPress-iOS-Editor-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-EditorDemo-WordPress-iOS-Editor-prefix.pch"; sourceTree = "<group>"; };
-		6A5A0E79F9A6A2E44FD39CED /* Pods-EditorDemoTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-EditorDemoTests.release.xcconfig"; sourceTree = "<group>"; };
-		6B52283D3232357AE696A170 /* Pods-EditorDemo-UIAlertView+Blocks.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-EditorDemo-UIAlertView+Blocks.xcconfig"; sourceTree = "<group>"; };
-		6C616AE8E697E93A6E37DFF3 /* AFHTTPRequestOperation.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AFHTTPRequestOperation.m; path = AFNetworking/AFHTTPRequestOperation.m; sourceTree = "<group>"; };
-		6CF49B02B746703CC492A022 /* jquery.mobile-events.min.js */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.javascript; path = "jquery.mobile-events.min.js"; sourceTree = "<group>"; };
-		6D16E030A7855D156F8D6873 /* WPNUXUtility.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = WPNUXUtility.m; path = "WordPress-iOS-Shared/Core/WPNUXUtility.m"; sourceTree = "<group>"; };
-		6DB2247E9DE38BAB3598AA4F /* UIWebView+GUIFixes.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "UIWebView+GUIFixes.m"; sourceTree = "<group>"; };
-		6F77D6834FCEB81B689C42BA /* Pods-EditorDemo.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-EditorDemo.release.xcconfig"; sourceTree = "<group>"; };
-		70DBC5EA925BD6CF3676657A /* WPImageMeta.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = WPImageMeta.h; sourceTree = "<group>"; };
-		7170B9F00A185ACE9C143787 /* HRColorPickerViewController.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = HRColorPickerViewController.h; sourceTree = "<group>"; };
-		7291752A749BD1FB9C8FD07B /* Pods-EditorDemo.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-EditorDemo.debug.xcconfig"; sourceTree = "<group>"; };
-		7333CC8C670AC325717EC433 /* Pods-EditorDemo-WordPress-iOS-Shared-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-EditorDemo-WordPress-iOS-Shared-prefix.pch"; sourceTree = "<group>"; };
-		73A06E71ACA570065D2E12FB /* icon-posts-editor-preview@3x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = "icon-posts-editor-preview@3x.png"; sourceTree = "<group>"; };
-		7406B0C79E10BBAC874DA0BE /* Pods-EditorDemo-WordPressCom-Analytics-iOS-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-EditorDemo-WordPressCom-Analytics-iOS-prefix.pch"; sourceTree = "<group>"; };
-		74357F1BFC1EC208F76D99A6 /* DDLog+LOGV.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "DDLog+LOGV.h"; path = "Classes/DDLog+LOGV.h"; sourceTree = "<group>"; };
-		75EF4EE3B758B6379239E1E2 /* WPDeviceIdentification.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = WPDeviceIdentification.m; path = "WordPress-iOS-Shared/Core/WPDeviceIdentification.m"; sourceTree = "<group>"; };
-		768BD1B9A7536355AE0F9F15 /* WPEditorLoggingConfiguration.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = WPEditorLoggingConfiguration.h; sourceTree = "<group>"; };
-		79A01D6C15846ECFFE1686F3 /* WPEditorLoggingConfiguration.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = WPEditorLoggingConfiguration.m; sourceTree = "<group>"; };
-		7C3132720A59BC1DD7C4FCDE /* DDMultiFormatter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = DDMultiFormatter.h; path = Classes/Extensions/DDMultiFormatter.h; sourceTree = "<group>"; };
-		7F115578DD3EB1A11998881C /* ZSShorizontalrule@2x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = "ZSShorizontalrule@2x.png"; sourceTree = "<group>"; };
-		7F2B7736B3A9D2D34A7E3E43 /* Pods-EditorDemo-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-EditorDemo-resources.sh"; sourceTree = "<group>"; };
-		809B94A47BD95CEFD6046AF3 /* icon_format_more.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = icon_format_more.png; sourceTree = "<group>"; };
-		80D829BCA25C76946462169A /* WPLegacyEditorViewController.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = WPLegacyEditorViewController.m; sourceTree = "<group>"; };
-		83B76071665DF829399714BF /* DDTTYLogger.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = DDTTYLogger.h; path = Classes/DDTTYLogger.h; sourceTree = "<group>"; };
-		8544E0C206CFCF4B12DF00FA /* ZSSoutdent.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = ZSSoutdent.png; sourceTree = "<group>"; };
-		855236319EC41323955AD9FB /* Pods-EditorDemo-WordPress-iOS-Shared.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-EditorDemo-WordPress-iOS-Shared.xcconfig"; sourceTree = "<group>"; };
-		85D185437C585F3172CDA947 /* ZSSh2.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = ZSSh2.png; sourceTree = "<group>"; };
-		865CB62E80D7764017A36D83 /* DDLog.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = DDLog.m; path = Classes/DDLog.m; sourceTree = "<group>"; };
-		86B2B8EBE5E7BD54D211245F /* HRCgUtil.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = HRCgUtil.m; sourceTree = "<group>"; };
-		87243AD8538521AD2434EC27 /* rangy-selectionsaverestore.js */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.javascript; path = "rangy-selectionsaverestore.js"; sourceTree = "<group>"; };
-		87EBE2210918C1BB7DB448B5 /* AFURLSessionManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AFURLSessionManager.h; path = AFNetworking/AFURLSessionManager.h; sourceTree = "<group>"; };
-		88FA75E4F70D037B1EFAAF75 /* WPEditorViewController.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = WPEditorViewController.m; sourceTree = "<group>"; };
-		89232286CA4A51F955BA4485 /* icon_format_bold.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = icon_format_bold.png; sourceTree = "<group>"; };
-		89235079FAB59221611D63CD /* DDASLLogger.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = DDASLLogger.m; path = Classes/DDASLLogger.m; sourceTree = "<group>"; };
-		8931B68A09E383CD904DD45B /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS8.3.sdk/System/Library/Frameworks/SystemConfiguration.framework; sourceTree = DEVELOPER_DIR; };
-		8966441CAECECED37C5A669F /* ZSSundo.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = ZSSundo.png; sourceTree = "<group>"; };
-		8A38F0FFC96FDCCDD12B1AFA /* HRColorUtil.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = HRColorUtil.h; sourceTree = "<group>"; };
-		8B606A313211700D3B8D617A /* Pods-EditorDemo-WordPress-iOS-Editor.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-EditorDemo-WordPress-iOS-Editor.xcconfig"; sourceTree = "<group>"; };
-		8BEB2D35D07C89F0DFD67FCE /* HRColorCursor.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = HRColorCursor.h; sourceTree = "<group>"; };
-		8CA0CC8A3814CF370038663E /* NSString+Util.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSString+Util.m"; path = "WordPress-iOS-Shared/Core/NSString+Util.m"; sourceTree = "<group>"; };
-		8D0C2D1CC4780CAC805D7061 /* icon_format_underline.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = icon_format_underline.png; sourceTree = "<group>"; };
-		8D7EC5A03EE293E016E05897 /* DDLogMacros.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = DDLogMacros.h; path = Classes/DDLogMacros.h; sourceTree = "<group>"; };
-		8D9774541DD39B37D7C9E281 /* ZSSoutdent@2x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = "ZSSoutdent@2x.png"; sourceTree = "<group>"; };
-		8EEF297308E4806240A577F9 /* AFURLSessionManager.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AFURLSessionManager.m; path = AFNetworking/AFURLSessionManager.m; sourceTree = "<group>"; };
-		90B5A89B7D038A784E82E264 /* icon_format_quote.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = icon_format_quote.png; sourceTree = "<group>"; };
-		92029A24BD00438DF69F3430 /* WPFontManager.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = WPFontManager.m; path = "WordPress-iOS-Shared/Core/WPFontManager.m"; sourceTree = "<group>"; };
-		924B5F6047D3307240D1F128 /* HRColorPickerView.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = HRColorPickerView.m; sourceTree = "<group>"; };
-		929BBF73903E060609B90773 /* UIWebView+AFNetworking.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIWebView+AFNetworking.m"; path = "UIKit+AFNetworking/UIWebView+AFNetworking.m"; sourceTree = "<group>"; };
-		92CFD91B9786B47D3D41F257 /* icon-posts-editor-preview.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = "icon-posts-editor-preview.png"; sourceTree = "<group>"; };
-		92FD2D1BB51543C99FB78845 /* AFURLResponseSerialization.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AFURLResponseSerialization.h; path = AFNetworking/AFURLResponseSerialization.h; sourceTree = "<group>"; };
-		934EAFA1098F1F101E8D964F /* icon-posts-editor-preview@2x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = "icon-posts-editor-preview@2x.png"; sourceTree = "<group>"; };
-		943522988A655FD84657E486 /* AFHTTPSessionManager.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AFHTTPSessionManager.m; path = AFNetworking/AFHTTPSessionManager.m; sourceTree = "<group>"; };
-		94D8943D1DD7246DC92AD2DB /* DDAbstractDatabaseLogger.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = DDAbstractDatabaseLogger.m; path = Classes/DDAbstractDatabaseLogger.m; sourceTree = "<group>"; };
-		9518F173377EFDE19D2D3CB6 /* icon_format_link.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = icon_format_link.png; sourceTree = "<group>"; };
-		95625436A073EB8182AEF56A /* Pods-EditorDemo-CocoaLumberjack-Private.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-EditorDemo-CocoaLumberjack-Private.xcconfig"; sourceTree = "<group>"; };
-		95B3FB54BCF2940567C3B742 /* WPHybridLogger.js */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.javascript; path = WPHybridLogger.js; sourceTree = "<group>"; };
-		974D2A9D4653F8E38D2F0C40 /* WPEditorField.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = WPEditorField.m; sourceTree = "<group>"; };
-		98A08728E71AC0662A9D1B85 /* ZSSh3.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = ZSSh3.png; sourceTree = "<group>"; };
-		98BC06F7B5A47776BD69A7BF /* ZSSrightjustify.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = ZSSrightjustify.png; sourceTree = "<group>"; };
-		98DF48F13D4655D8543E518B /* DDASLLogger.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = DDASLLogger.h; path = Classes/DDASLLogger.h; sourceTree = "<group>"; };
-		98EE8483A445597F06C792DE /* HRBrightnessCursor.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = HRBrightnessCursor.m; sourceTree = "<group>"; };
-		99CCFD2E23B202A3D27BA362 /* editor.html */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.html; path = editor.html; sourceTree = "<group>"; };
-		9AFDF5C977A47006BC807E8F /* CYRLayoutManager.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = CYRLayoutManager.m; sourceTree = "<group>"; };
-		9B776362EEBDA487D94530EF /* icon_format_keyboard.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = icon_format_keyboard.png; sourceTree = "<group>"; };
-		9BDE7351115956FDB2791E85 /* icon_format_ol.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = icon_format_ol.png; sourceTree = "<group>"; };
-		9C5C3884916463A51CB01472 /* libPods-EditorDemo-WordPress-iOS-Editor.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-EditorDemo-WordPress-iOS-Editor.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		9D3595BFBDFDEB62A1D59A6D /* Pods-EditorDemo-CocoaLumberjack-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-EditorDemo-CocoaLumberjack-dummy.m"; sourceTree = "<group>"; };
-		9D753DED78C2802CE68C3A41 /* icon-posts-editor-inspector@3x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = "icon-posts-editor-inspector@3x.png"; sourceTree = "<group>"; };
-		9D77FE1E5CA966152EEB3DE9 /* WPEditorToolbarView.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = WPEditorToolbarView.h; sourceTree = "<group>"; };
-		9E66B9064D6118FA70A78B26 /* ZSSquicklink.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = ZSSquicklink.png; sourceTree = "<group>"; };
-		9E986D24AFB113B21A461F3C /* UITableViewTextFieldCell.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = UITableViewTextFieldCell.m; path = "WordPress-iOS-Shared/Core/UITableViewTextFieldCell.m"; sourceTree = "<group>"; };
-		A23DAF8B4FD9C9CA1D33FEBD /* NSString+XMLExtensions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSString+XMLExtensions.m"; path = "WordPress-iOS-Shared/Core/NSString+XMLExtensions.m"; sourceTree = "<group>"; };
-		A261037F1CFEE61E5ABF30E8 /* Merriweather-Light.ttf */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = file; name = "Merriweather-Light.ttf"; path = "WordPress-iOS-Shared/Assets/Merriweather-Light.ttf"; sourceTree = "<group>"; };
-		A26F4D31A1E5025CB011DAB6 /* OpenSans-BoldItalic.ttf */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = file; name = "OpenSans-BoldItalic.ttf"; path = "WordPress-iOS-Shared/Assets/OpenSans-BoldItalic.ttf"; sourceTree = "<group>"; };
-		A27F58444DE8AE0E76350099 /* UIProgressView+AFNetworking.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIProgressView+AFNetworking.m"; path = "UIKit+AFNetworking/UIProgressView+AFNetworking.m"; sourceTree = "<group>"; };
-		A4620A669C2CBFCE0D47740A /* ZSSh5@2x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = "ZSSh5@2x.png"; sourceTree = "<group>"; };
-		A48F9E3F5784859E655DB860 /* AFURLRequestSerialization.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AFURLRequestSerialization.h; path = AFNetworking/AFURLRequestSerialization.h; sourceTree = "<group>"; };
-		A54E2D46D6A0A3F6C1B62CF0 /* ZSSh2@2x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = "ZSSh2@2x.png"; sourceTree = "<group>"; };
-		A6312DEE7C6B844FAC135D92 /* ZSSleftjustify.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = ZSSleftjustify.png; sourceTree = "<group>"; };
-		A6BFF4669D8CBC787478BC99 /* Pods-EditorDemo-WordPressCom-Analytics-iOS-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-EditorDemo-WordPressCom-Analytics-iOS-dummy.m"; sourceTree = "<group>"; };
-		A82B16455309483C9C249630 /* CYRLayoutManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = CYRLayoutManager.h; sourceTree = "<group>"; };
-		A83EBE9737B76BD1DB10EB25 /* HRBrightnessCursor.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = HRBrightnessCursor.h; sourceTree = "<group>"; };
-		A95002292EBA0A8E1A8D96C5 /* ZSStextcolor@2x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = "ZSStextcolor@2x.png"; sourceTree = "<group>"; };
-		A95615B899E0D9F831A4EFC9 /* ZSSsubscript@2x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = "ZSSsubscript@2x.png"; sourceTree = "<group>"; };
-		A98ED62295FA964CAEA8F433 /* Pods-EditorDemo-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-EditorDemo-acknowledgements.markdown"; sourceTree = "<group>"; };
-		AACF3AC0715A74F944856827 /* Pods-EditorDemo-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-EditorDemo-dummy.m"; sourceTree = "<group>"; };
-		AB0222DB5D4D25C5B5EA30BF /* WPDeviceIdentification.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = WPDeviceIdentification.h; path = "WordPress-iOS-Shared/Core/WPDeviceIdentification.h"; sourceTree = "<group>"; };
-		AB056485C7A7A2F6AE95F541 /* HRColorCursor.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = HRColorCursor.m; sourceTree = "<group>"; };
-		AB1B4D0769C3B24AF938ECE4 /* CYRTextStorage.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = CYRTextStorage.m; sourceTree = "<group>"; };
-		ABA387D73D80CA20A00660D6 /* ZSSRichTextEditor.js */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.javascript; path = ZSSRichTextEditor.js; sourceTree = "<group>"; };
-		ACF6EAEB12FC49237A334321 /* ZSSredo.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = ZSSredo.png; sourceTree = "<group>"; };
-		AD705BBE73395931249E6A99 /* Pods-EditorDemo-WordPress-iOS-Editor-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-EditorDemo-WordPress-iOS-Editor-dummy.m"; sourceTree = "<group>"; };
-		AD955A9EED4C718A51BAF067 /* WPEditorToolbarButton.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = WPEditorToolbarButton.m; sourceTree = "<group>"; };
-		AFF499A9B99688E9DF426A19 /* icon_format_ul@2x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = "icon_format_ul@2x.png"; sourceTree = "<group>"; };
-		B1D00CD591028EF5127CD697 /* rangy-core.js */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.javascript; path = "rangy-core.js"; sourceTree = "<group>"; };
-		B1D6D1525F0819EBB8B9A02D /* ZSSBarButtonItem.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = ZSSBarButtonItem.m; sourceTree = "<group>"; };
-		B46B33D534E8A4F34D7096F7 /* WPLegacyKeyboardToolbarDone.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = WPLegacyKeyboardToolbarDone.h; sourceTree = "<group>"; };
-		B563C04BA3C2A510A9F8495F /* NSObject+SafeExpectations.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "NSObject+SafeExpectations.h"; sourceTree = "<group>"; };
-		B752A1B22EEBA84AAB04BC43 /* AFURLConnectionOperation.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AFURLConnectionOperation.m; path = AFNetworking/AFURLConnectionOperation.m; sourceTree = "<group>"; };
-		B76B72C0429B654F78ABED10 /* WPTableViewCell.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = WPTableViewCell.h; path = "WordPress-iOS-Shared/Core/WPTableViewCell.h"; sourceTree = "<group>"; };
-		BA17E35CEDDB3D58BD6B6A8D /* DDDispatchQueueLogFormatter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = DDDispatchQueueLogFormatter.m; path = Classes/Extensions/DDDispatchQueueLogFormatter.m; sourceTree = "<group>"; };
-		BBFF0636DD0ACBEF7709787A /* NSDictionary+SafeExpectations.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "NSDictionary+SafeExpectations.m"; sourceTree = "<group>"; };
-		BBFFAAEA0B13ACEC5DCD402D /* ZSSTextView.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = ZSSTextView.m; sourceTree = "<group>"; };
-		BC2035E92C1E87AA65F80397 /* WPImageSource.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = WPImageSource.m; path = "WordPress-iOS-Shared/Core/WPImageSource.m"; sourceTree = "<group>"; };
-		BC5F8CC72F610AF6F2377B5E /* CYRToken.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = CYRToken.h; sourceTree = "<group>"; };
-		BCE044252C4D68BE0AF67ED8 /* WPLegacyKeyboardToolbarButtonItem.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = WPLegacyKeyboardToolbarButtonItem.m; sourceTree = "<group>"; };
-		BD1E570EF8189D86464C0E2C /* WPImageMeta.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = WPImageMeta.m; sourceTree = "<group>"; };
-		BD83FC20EC006449066C6FA1 /* Pods-EditorDemoTests-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-EditorDemoTests-resources.sh"; sourceTree = "<group>"; };
-		BED91EE72D776DEC97ED65AC /* WPLegacyKeyboardToolbarDone.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = WPLegacyKeyboardToolbarDone.m; sourceTree = "<group>"; };
-		BF05E9C99DBD7D58BD72C47B /* Merriweather-LightItalic.otf */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = file; name = "Merriweather-LightItalic.otf"; path = "WordPress-iOS-Shared/Assets/Merriweather-LightItalic.otf"; sourceTree = "<group>"; };
-		BFF08FB8ED207559997CDFB2 /* WPLegacyKeyboardToolbarButtonItem.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = WPLegacyKeyboardToolbarButtonItem.h; sourceTree = "<group>"; };
-		C177B27AF8DF7D5DDF5266C0 /* UIImage+Util.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIImage+Util.m"; path = "WordPress-iOS-Shared/Core/UIImage+Util.m"; sourceTree = "<group>"; };
-		C2A651F702836255E1BF6923 /* OpenSans-LightItalic.ttf */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = file; name = "OpenSans-LightItalic.ttf"; path = "WordPress-iOS-Shared/Assets/OpenSans-LightItalic.ttf"; sourceTree = "<group>"; };
-		C2DFA4D92395995F6A5C81B0 /* ZSSrightjustify@2x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = "ZSSrightjustify@2x.png"; sourceTree = "<group>"; };
-		C38F10D5752B2DF9D6BD9D6A /* icon_format_underline@2x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = "icon_format_underline@2x.png"; sourceTree = "<group>"; };
-		C403C7B8F58A796C79509BFB /* WPLegacyEditorViewController.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = WPLegacyEditorViewController.h; sourceTree = "<group>"; };
-		C569177FBD9DC3B1C3D9A082 /* ZSSBarButtonItem.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = ZSSBarButtonItem.h; sourceTree = "<group>"; };
-		C62728416E4B3FA0654C4627 /* UIActivityIndicatorView+AFNetworking.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIActivityIndicatorView+AFNetworking.m"; path = "UIKit+AFNetworking/UIActivityIndicatorView+AFNetworking.m"; sourceTree = "<group>"; };
-		C6B28B188BC62FD0DDF829FC /* WPAnalytics.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = WPAnalytics.h; path = "WordPressCom-Analytics-iOS/WPAnalytics.h"; sourceTree = "<group>"; };
-		C74D92E6172B18645410B660 /* Pods-EditorDemo-AFNetworking-Private.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-EditorDemo-AFNetworking-Private.xcconfig"; sourceTree = "<group>"; };
-		C792E809F612994119012AF7 /* wpload.js */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.javascript; path = wpload.js; sourceTree = "<group>"; };
-		C80A806DD95999A06EF1959D /* DDAssertMacros.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = DDAssertMacros.h; path = Classes/DDAssertMacros.h; sourceTree = "<group>"; };
-		C92A8CEBF014239853F143AB /* AFSecurityPolicy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AFSecurityPolicy.m; path = AFNetworking/AFSecurityPolicy.m; sourceTree = "<group>"; };
-		CB265E7E9BFBE7B8AFF25B49 /* Pods-EditorDemo-AFNetworking.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-EditorDemo-AFNetworking.xcconfig"; sourceTree = "<group>"; };
-		CDBB1FD933AF6AF88966E053 /* AFNetworkActivityIndicatorManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AFNetworkActivityIndicatorManager.h; path = "UIKit+AFNetworking/AFNetworkActivityIndicatorManager.h"; sourceTree = "<group>"; };
-		CE66C4E4B2D48353ED45A4F9 /* icon_format_italic@2x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = "icon_format_italic@2x.png"; sourceTree = "<group>"; };
-		CED050E53B65F55252827DB2 /* Pods-EditorDemo-WordPress-iOS-Shared-Private.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-EditorDemo-WordPress-iOS-Shared-Private.xcconfig"; sourceTree = "<group>"; };
-		CF333F81303BC03D65260EEE /* ZSSindent.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = ZSSindent.png; sourceTree = "<group>"; };
-		D219F8203537E059C077C940 /* icon_format_media.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = icon_format_media.png; sourceTree = "<group>"; };
-		D27F9BD3C4703DA8BD2AC9FB /* UIButton+AFNetworking.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIButton+AFNetworking.m"; path = "UIKit+AFNetworking/UIButton+AFNetworking.m"; sourceTree = "<group>"; };
-		D3C8E408F68FC445587C5424 /* icon_format_strikethrough@3x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = "icon_format_strikethrough@3x.png"; sourceTree = "<group>"; };
-		D5213EE2040E6B3573D93D9A /* AFNetworking.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AFNetworking.h; path = AFNetworking/AFNetworking.h; sourceTree = "<group>"; };
-		D5AADFE47F9D90E4AFDA2477 /* icon-posts-editor-inspector.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = "icon-posts-editor-inspector.png"; sourceTree = "<group>"; };
-		D6E546B2C69B6D23F6A3175A /* WPTableViewSectionHeaderView.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = WPTableViewSectionHeaderView.h; path = "WordPress-iOS-Shared/Core/WPTableViewSectionHeaderView.h"; sourceTree = "<group>"; };
-		D70B21F06CD25FEAF9117297 /* wpsave.js */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.javascript; path = wpsave.js; sourceTree = "<group>"; };
-		D8204AE0034E79F2CE50C5C8 /* UIActivityIndicatorView+AFNetworking.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIActivityIndicatorView+AFNetworking.h"; path = "UIKit+AFNetworking/UIActivityIndicatorView+AFNetworking.h"; sourceTree = "<group>"; };
-		D890A4D0818F60CA97317E36 /* Pods-EditorDemoTests-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-EditorDemoTests-acknowledgements.markdown"; sourceTree = "<group>"; };
-		D8B21B104C492B33C5198F0C /* CYRToken.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = CYRToken.m; sourceTree = "<group>"; };
-		D8F18A6D0A8419F77D340D21 /* WPEditorView.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = WPEditorView.m; sourceTree = "<group>"; };
-		DCAD6D44CF75602B883DB7B2 /* HRColorUtil.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = HRColorUtil.m; sourceTree = "<group>"; };
-		DDF2FE148226BF7142422149 /* rangy-serializer.js */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.javascript; path = "rangy-serializer.js"; sourceTree = "<group>"; };
-		DECA1FA5912BF385D4C72FBA /* AFNetworkReachabilityManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AFNetworkReachabilityManager.h; path = AFNetworking/AFNetworkReachabilityManager.h; sourceTree = "<group>"; };
-		DF0F502A0B28ED74BF7672A7 /* shortcode.js */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.javascript; path = shortcode.js; sourceTree = "<group>"; };
-		DF23B2473711D04DCCCF8D23 /* DDFileLogger.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = DDFileLogger.m; path = Classes/DDFileLogger.m; sourceTree = "<group>"; };
-		DFC722E6F6F78F683ECC3D33 /* AFSecurityPolicy.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AFSecurityPolicy.h; path = AFNetworking/AFSecurityPolicy.h; sourceTree = "<group>"; };
-		E07BCBF46CA37C59069257EF /* WPEditorView.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = WPEditorView.h; sourceTree = "<group>"; };
-		E1851933ADEEDE4F6D7433FC /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS8.3.sdk/System/Library/Frameworks/CoreGraphics.framework; sourceTree = DEVELOPER_DIR; };
-		E1C99FFBBFB8B9404F1576C1 /* icon_format_ul.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = icon_format_ul.png; sourceTree = "<group>"; };
-		E28E7089D526CDD36B58F701 /* ZSSh4.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = ZSSh4.png; sourceTree = "<group>"; };
-		E32BBF04BBF9BDAF1DA8BD9D /* DDLog.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = DDLog.h; path = Classes/DDLog.h; sourceTree = "<group>"; };
-		E50FB26B160A58EF2B22DC7E /* UITableViewTextFieldCell.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = UITableViewTextFieldCell.h; path = "WordPress-iOS-Shared/Core/UITableViewTextFieldCell.h"; sourceTree = "<group>"; };
-		E55877D05E8A4C6E80EC12CF /* underscore-min.js */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.javascript; path = "underscore-min.js"; sourceTree = "<group>"; };
-		E55DD7A1E3B91C809FA29A87 /* UIImageView+AFNetworking.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIImageView+AFNetworking.m"; path = "UIKit+AFNetworking/UIImageView+AFNetworking.m"; sourceTree = "<group>"; };
-		E5917ED7054745EA2D4ED57C /* icon_format_keyboard@2x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = "icon_format_keyboard@2x.png"; sourceTree = "<group>"; };
-		E7A1DB0FDF5244C4E92C208D /* CYRTextStorage.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = CYRTextStorage.h; sourceTree = "<group>"; };
-		E7E1CD7B14E2AA11BFA963F9 /* ZSSindent@2x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = "ZSSindent@2x.png"; sourceTree = "<group>"; };
-		E7FE277C295E137B551C1D28 /* WPEditorField.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = WPEditorField.h; sourceTree = "<group>"; };
-		E80814E3E0FB2924CA17448D /* ZSSh1.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = ZSSh1.png; sourceTree = "<group>"; };
-		E8DEAB12964765566D166BD7 /* Pods-EditorDemo-NSObject-SafeExpectations.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-EditorDemo-NSObject-SafeExpectations.xcconfig"; sourceTree = "<group>"; };
-		E9864BD97C3640399FB37841 /* ZSSundo@2x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = "ZSSundo@2x.png"; sourceTree = "<group>"; };
-		EAD51AE82173321DB6E8561F /* ZSSclearstyle@2x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = "ZSSclearstyle@2x.png"; sourceTree = "<group>"; };
-		EB33533D90A0124759E562AA /* Pods-EditorDemo-CocoaLumberjack.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-EditorDemo-CocoaLumberjack.xcconfig"; sourceTree = "<group>"; };
-		EBC991C6DFE83D4D4C3784D2 /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS8.3.sdk/System/Library/Frameworks/Security.framework; sourceTree = DEVELOPER_DIR; };
-		EC0D1CB18E1778F3B303AFEC /* ZSSsubscript.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = ZSSsubscript.png; sourceTree = "<group>"; };
-		EC1590E1BC559108B7931F2B /* libPods-EditorDemoTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-EditorDemoTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		EC16E24A8EF5C39FA394C9AB /* ZSShorizontalrule.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = ZSShorizontalrule.png; sourceTree = "<group>"; };
-		EC8495EA7D6F0DE9DC90C99F /* UIColor+Helpers.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIColor+Helpers.h"; path = "WordPress-iOS-Shared/Core/UIColor+Helpers.h"; sourceTree = "<group>"; };
-		EC99DF31A210C785E8C03009 /* WPEditorViewController.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = WPEditorViewController.h; sourceTree = "<group>"; };
-		EF4686D53017634E6BEBA1CF /* DDAbstractDatabaseLogger.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = DDAbstractDatabaseLogger.h; path = Classes/DDAbstractDatabaseLogger.h; sourceTree = "<group>"; };
-		EF8E2060D208EF60883E9394 /* AFNetworkReachabilityManager.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AFNetworkReachabilityManager.m; path = AFNetworking/AFNetworkReachabilityManager.m; sourceTree = "<group>"; };
-		EFC7E7D7222CB606DE916907 /* HRColorPickerMacros.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = HRColorPickerMacros.h; sourceTree = "<group>"; };
-		F166847A9F567DFFFEF0018C /* editor.css */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.css; path = editor.css; sourceTree = "<group>"; };
-		F1A97083BD0FC62B75E9E95C /* ZSSforcejustify@2x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = "ZSSforcejustify@2x.png"; sourceTree = "<group>"; };
-		F1A9AB7D49A0C6AA9AEE8636 /* WPNoResultsView.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = WPNoResultsView.h; path = "WordPress-iOS-Shared/Core/WPNoResultsView.h"; sourceTree = "<group>"; };
-		F1C19E889B85B3DB19953FD0 /* ZSSforcejustify.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = ZSSforcejustify.png; sourceTree = "<group>"; };
-		F2EE065202518018D189961F /* rangy-highlighter.js */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.javascript; path = "rangy-highlighter.js"; sourceTree = "<group>"; };
-		F2FB0FD195C1EE60554B3A05 /* ZSSsuperscript.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = ZSSsuperscript.png; sourceTree = "<group>"; };
-		F399A5BAACE5836A5E67EF4C /* AFURLResponseSerialization.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AFURLResponseSerialization.m; path = AFNetworking/AFURLResponseSerialization.m; sourceTree = "<group>"; };
-		F410F168BE4F71C9887D9930 /* icon_format_strikethrough@2x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = "icon_format_strikethrough@2x.png"; sourceTree = "<group>"; };
-		F5DFFC76E7319AEF6B1E3BC9 /* ZSSredo@2x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = "ZSSredo@2x.png"; sourceTree = "<group>"; };
-		F6EB761F023C2915B634E16C /* CocoaLumberjack.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = CocoaLumberjack.h; path = Classes/CocoaLumberjack.h; sourceTree = "<group>"; };
-		F6EEAF6E918D64B1B7AF9C33 /* AFHTTPRequestOperationManager.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AFHTTPRequestOperationManager.m; path = AFNetworking/AFHTTPRequestOperationManager.m; sourceTree = "<group>"; };
-		F79DFC09DF5D304117C8C985 /* UIWebView+GUIFixes.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "UIWebView+GUIFixes.h"; sourceTree = "<group>"; };
-		F7B60B3A45487A8D0FE93430 /* NSString+Util.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSString+Util.h"; path = "WordPress-iOS-Shared/Core/NSString+Util.h"; sourceTree = "<group>"; };
-		F83111084A8B84059A5EC7AC /* icon_format_strikethrough.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = icon_format_strikethrough.png; sourceTree = "<group>"; };
-		F8B92DA817029F2EA817CCD9 /* DDMultiFormatter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = DDMultiFormatter.m; path = Classes/Extensions/DDMultiFormatter.m; sourceTree = "<group>"; };
-		F957BAE1810901BBCD142A36 /* AFHTTPSessionManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AFHTTPSessionManager.h; path = AFNetworking/AFHTTPSessionManager.h; sourceTree = "<group>"; };
-		F9BD038AD678226BAB2F4E6F /* WPAnalytics.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = WPAnalytics.m; path = "WordPressCom-Analytics-iOS/WPAnalytics.m"; sourceTree = "<group>"; };
-		FA98D8A5A16AE9A1DB0FE6B8 /* icon_format_media@3x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = "icon_format_media@3x.png"; sourceTree = "<group>"; };
-		FB0E6E4AEFB946AD32EF2296 /* HRColorPickerViewController.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = HRColorPickerViewController.m; sourceTree = "<group>"; };
-		FC3B0027056C09810D6BE3F6 /* icon_format_bold@3x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = "icon_format_bold@3x.png"; sourceTree = "<group>"; };
-		FCC00753D323882477103756 /* icon_options@2x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = "icon_options@2x.png"; sourceTree = "<group>"; };
-		FDD4B3EA92489A784DB3B3E7 /* WPTableViewSectionFooterView.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = WPTableViewSectionFooterView.h; path = "WordPress-iOS-Shared/Core/WPTableViewSectionFooterView.h"; sourceTree = "<group>"; };
-		FF90D05A0C2E91FB332DA879 /* icon_format_html@2x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = "icon_format_html@2x.png"; sourceTree = "<group>"; };
-		FFC30D7354170D919C616AE4 /* icon_format_quote@2x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = "icon_format_quote@2x.png"; sourceTree = "<group>"; };
+		002154DF256B9144662854F6 /* ZSSquicklink@2x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = "ZSSquicklink@2x.png"; sourceTree = "<group>"; };
+		00AEED7B8808F9F44CC44207 /* Pods-EditorDemo-CocoaLumberjack.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-EditorDemo-CocoaLumberjack.xcconfig"; sourceTree = "<group>"; };
+		00BF11F0F937DCF9D754D429 /* editor.css */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.css; path = editor.css; sourceTree = "<group>"; };
+		01B925E4371AA877422D1B0E /* UIColor+Helpers.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIColor+Helpers.m"; path = "WordPress-iOS-Shared/Core/UIColor+Helpers.m"; sourceTree = "<group>"; };
+		01F1CBD60F6C20CB7E44D7A9 /* js-beautifier.js */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.javascript; path = "js-beautifier.js"; sourceTree = "<group>"; };
+		035B336B3ECB594B6A8A342A /* DDASLLogger.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = DDASLLogger.m; path = Classes/DDASLLogger.m; sourceTree = "<group>"; };
+		035D98E3238B5312570CDE80 /* AFURLConnectionOperation.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AFURLConnectionOperation.m; path = AFNetworking/AFURLConnectionOperation.m; sourceTree = "<group>"; };
+		03681D95AF9171E060FCCA7E /* HRColorCursor.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = HRColorCursor.h; sourceTree = "<group>"; };
+		042A4BC8EC33097B7112E4E4 /* icon-posts-editor-inspector.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = "icon-posts-editor-inspector.png"; sourceTree = "<group>"; };
+		042F776A7301B5A6AB041FEC /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS8.3.sdk/System/Library/Frameworks/SystemConfiguration.framework; sourceTree = DEVELOPER_DIR; };
+		06183EBBC512138990CDA43A /* icon_format_more@3x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = "icon_format_more@3x.png"; sourceTree = "<group>"; };
+		07BE82A30BE140F5FBA496B2 /* icon_format_ul.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = icon_format_ul.png; sourceTree = "<group>"; };
+		07FAE5BC824445454A51531B /* DDDispatchQueueLogFormatter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = DDDispatchQueueLogFormatter.m; path = Classes/Extensions/DDDispatchQueueLogFormatter.m; sourceTree = "<group>"; };
+		0A6C6981CB3A9AB208AF5077 /* WPHybridLogger.js */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.javascript; path = WPHybridLogger.js; sourceTree = "<group>"; };
+		0F282BBD8F9CEAA3F56CFACF /* AFHTTPRequestOperation.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AFHTTPRequestOperation.m; path = AFNetworking/AFHTTPRequestOperation.m; sourceTree = "<group>"; };
+		0F4C1C6D7959E19FE3017BEC /* UIWebView+GUIFixes.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "UIWebView+GUIFixes.m"; sourceTree = "<group>"; };
+		11E91DAED85154EDDD70659B /* DDASLLogger.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = DDASLLogger.h; path = Classes/DDASLLogger.h; sourceTree = "<group>"; };
+		12AA85A80517CD6A41F53C45 /* icon_format_strikethrough@3x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = "icon_format_strikethrough@3x.png"; sourceTree = "<group>"; };
+		144E096C30FCE5B9ED0E4745 /* ZSSh2.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = ZSSh2.png; sourceTree = "<group>"; };
+		1467471810E54CD74871A4E3 /* Pods-EditorDemoTests-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-EditorDemoTests-acknowledgements.plist"; sourceTree = "<group>"; };
+		14AE24E316D8F65360CC822D /* Pods-EditorDemo-WordPress-iOS-Shared-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-EditorDemo-WordPress-iOS-Shared-prefix.pch"; sourceTree = "<group>"; };
+		14FAEE7679908D8D4E78E82D /* icon_format_link@3x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = "icon_format_link@3x.png"; sourceTree = "<group>"; };
+		171117ED200E1725AC9E49EC /* rangy-textrange.js */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.javascript; path = "rangy-textrange.js"; sourceTree = "<group>"; };
+		1715BBEFB6401E99EA712D71 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS8.3.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
+		173EFF3D168DF9D6CB096083 /* ZSSh5.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = ZSSh5.png; sourceTree = "<group>"; };
+		17836B3819D3E41E6A225C3E /* AFHTTPSessionManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AFHTTPSessionManager.h; path = AFNetworking/AFHTTPSessionManager.h; sourceTree = "<group>"; };
+		17AFACC2BDB34CFFF477DD38 /* DDMultiFormatter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = DDMultiFormatter.h; path = Classes/Extensions/DDMultiFormatter.h; sourceTree = "<group>"; };
+		1838BF695A15C46138327B6A /* HRColorPickerViewController.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = HRColorPickerViewController.h; sourceTree = "<group>"; };
+		184CDEC9AEEA4AB4456EE297 /* OpenSans-Light.ttf */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = file; name = "OpenSans-Light.ttf"; path = "WordPress-iOS-Shared/Assets/OpenSans-Light.ttf"; sourceTree = "<group>"; };
+		18A705C1D1A09576152A5618 /* DDLogMacros.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = DDLogMacros.h; path = Classes/DDLogMacros.h; sourceTree = "<group>"; };
+		18FBB2E8FC94F4DD1F05C44B /* DDAbstractDatabaseLogger.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = DDAbstractDatabaseLogger.m; path = Classes/DDAbstractDatabaseLogger.m; sourceTree = "<group>"; };
+		19170C331BCCE321FE86CD4E /* editor.html */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.html; path = editor.html; sourceTree = "<group>"; };
+		199BD5014705CEACB439CE05 /* UIAlertView+Blocks.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "UIAlertView+Blocks.m"; sourceTree = "<group>"; };
+		19F2F93215C85CCACB2C8711 /* ZSSh2@2x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = "ZSSh2@2x.png"; sourceTree = "<group>"; };
+		1A22270E1206E29078682CCB /* AFNetworkActivityIndicatorManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AFNetworkActivityIndicatorManager.h; path = "UIKit+AFNetworking/AFNetworkActivityIndicatorManager.h"; sourceTree = "<group>"; };
+		1A2D8BDD76F6A5CBC9F5261C /* ZSSquicklink.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = ZSSquicklink.png; sourceTree = "<group>"; };
+		1AB7A659E7CEB4106CF7E4DD /* CYRLayoutManager.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = CYRLayoutManager.m; sourceTree = "<group>"; };
+		1CCAE57FEC1C895A4E96866F /* wpsave.js */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.javascript; path = wpsave.js; sourceTree = "<group>"; };
+		1CF756A4E117BC1ADDD7961B /* icon_format_html@2x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = "icon_format_html@2x.png"; sourceTree = "<group>"; };
+		1D5487200DB87D47FC5C41C6 /* UIWebView+AFNetworking.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIWebView+AFNetworking.m"; path = "UIKit+AFNetworking/UIWebView+AFNetworking.m"; sourceTree = "<group>"; };
+		1D5E3538FDAB7AD423034561 /* NSObject+SafeExpectations.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "NSObject+SafeExpectations.h"; sourceTree = "<group>"; };
+		1EDE70E77E6648CB61DA42CE /* icon-posts-editor-preview.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = "icon-posts-editor-preview.png"; sourceTree = "<group>"; };
+		1F0315D2417746F806EEE93F /* icon_format_ul@3x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = "icon_format_ul@3x.png"; sourceTree = "<group>"; };
+		1F2E7064DF0BA8CF58089FB9 /* WPLegacyKeyboardToolbarDone.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = WPLegacyKeyboardToolbarDone.m; sourceTree = "<group>"; };
+		1FCCA2B00BB1F33D689FB5C4 /* Pods-EditorDemoTests-environment.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-EditorDemoTests-environment.h"; sourceTree = "<group>"; };
+		202F5E43C3E3A51610693AD5 /* WPEditorViewController.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = WPEditorViewController.h; sourceTree = "<group>"; };
+		20FFC3040AD5EA1F30BC554C /* Pods-EditorDemoTests-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-EditorDemoTests-resources.sh"; sourceTree = "<group>"; };
+		21C47F828590E876B82D76E0 /* Pods-EditorDemo-WordPress-iOS-Shared.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-EditorDemo-WordPress-iOS-Shared.xcconfig"; sourceTree = "<group>"; };
+		21DB075E84A404505D765751 /* ZSSforcejustify@2x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = "ZSSforcejustify@2x.png"; sourceTree = "<group>"; };
+		22D44D1AE026AFC29A21973D /* OpenSans-LightItalic.ttf */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = file; name = "OpenSans-LightItalic.ttf"; path = "WordPress-iOS-Shared/Assets/OpenSans-LightItalic.ttf"; sourceTree = "<group>"; };
+		23A06DEFC23188E688169C2D /* WPEditorView.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = WPEditorView.h; sourceTree = "<group>"; };
+		23DAB0AF2138D2938B81C209 /* icon-posts-editor-preview@3x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = "icon-posts-editor-preview@3x.png"; sourceTree = "<group>"; };
+		242FC6638990FE497706BE53 /* CYRToken.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = CYRToken.m; sourceTree = "<group>"; };
+		247B65CB971D5625EDD4D07F /* icon_format_unlink@2x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = "icon_format_unlink@2x.png"; sourceTree = "<group>"; };
+		2669244F4C29C037108616F3 /* WPHybridCallbacker.js */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.javascript; path = WPHybridCallbacker.js; sourceTree = "<group>"; };
+		2849F0104A3F2D6D00745B1D /* AFSecurityPolicy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AFSecurityPolicy.m; path = AFNetworking/AFSecurityPolicy.m; sourceTree = "<group>"; };
+		28775F67E478EDD244AE7627 /* MobileCoreServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MobileCoreServices.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS8.3.sdk/System/Library/Frameworks/MobileCoreServices.framework; sourceTree = DEVELOPER_DIR; };
+		28868A31B71EE7737F86D101 /* UIImageView+AFNetworking.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIImageView+AFNetworking.m"; path = "UIKit+AFNetworking/UIImageView+AFNetworking.m"; sourceTree = "<group>"; };
+		289EF6335C5A9E59F891F170 /* Pods-EditorDemoTests-CocoaLumberjack-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "Pods-EditorDemoTests-CocoaLumberjack-prefix.pch"; path = "../Pods-EditorDemoTests-CocoaLumberjack/Pods-EditorDemoTests-CocoaLumberjack-prefix.pch"; sourceTree = "<group>"; };
+		2B46CD62B020877E8FB677F2 /* Pods-EditorDemo-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-EditorDemo-acknowledgements.plist"; sourceTree = "<group>"; };
+		2BB856A005EC089D8C5D43C8 /* DDLog+LOGV.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "DDLog+LOGV.h"; path = "Classes/DDLog+LOGV.h"; sourceTree = "<group>"; };
+		2E66D244D542F23A3C2B98C2 /* DDContextFilterLogFormatter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = DDContextFilterLogFormatter.h; path = Classes/Extensions/DDContextFilterLogFormatter.h; sourceTree = "<group>"; };
+		2ED670FD22CA40E59803C5DA /* AFSecurityPolicy.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AFSecurityPolicy.h; path = AFNetworking/AFSecurityPolicy.h; sourceTree = "<group>"; };
+		2EE706467EA5CF1BFAD412F6 /* libPods-EditorDemo.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-EditorDemo.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		2FAC1F4B3EA04E156178F03A /* WPStyleGuide.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = WPStyleGuide.h; path = "WordPress-iOS-Shared/Core/WPStyleGuide.h"; sourceTree = "<group>"; };
+		2FC4A195DA0EB213FF64569A /* Pods-EditorDemo-UIAlertView+Blocks-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-EditorDemo-UIAlertView+Blocks-dummy.m"; sourceTree = "<group>"; };
+		30859BF8628CBD0DE0A5AF66 /* OpenSans-Italic.ttf */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = file; name = "OpenSans-Italic.ttf"; path = "WordPress-iOS-Shared/Assets/OpenSans-Italic.ttf"; sourceTree = "<group>"; };
+		311C6EDA025611DECCA08315 /* UIActivityIndicatorView+AFNetworking.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIActivityIndicatorView+AFNetworking.m"; path = "UIKit+AFNetworking/UIActivityIndicatorView+AFNetworking.m"; sourceTree = "<group>"; };
+		323C2D888D8D00B6B4460635 /* icon_format_underline.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = icon_format_underline.png; sourceTree = "<group>"; };
+		331E0B9FC63B0EB5802BCC21 /* AFURLResponseSerialization.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AFURLResponseSerialization.h; path = AFNetworking/AFURLResponseSerialization.h; sourceTree = "<group>"; };
+		33DD6C763204232C4ED4802B /* ZSShorizontalrule.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = ZSShorizontalrule.png; sourceTree = "<group>"; };
+		341CC9FE4B6F4A8B762446E2 /* UIRefreshControl+AFNetworking.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIRefreshControl+AFNetworking.h"; path = "UIKit+AFNetworking/UIRefreshControl+AFNetworking.h"; sourceTree = "<group>"; };
+		34709FADBBDA7A7B1005CD94 /* WPNUXUtility.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = WPNUXUtility.m; path = "WordPress-iOS-Shared/Core/WPNUXUtility.m"; sourceTree = "<group>"; };
+		3473C21F8B5263449BD7A604 /* libPods-EditorDemoTests-CocoaLumberjack.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-EditorDemoTests-CocoaLumberjack.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		34F665A048D8767C59B6289B /* Pods-EditorDemo-WordPressCom-Analytics-iOS-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-EditorDemo-WordPressCom-Analytics-iOS-prefix.pch"; sourceTree = "<group>"; };
+		35B5684797DBC61EB1EDE504 /* OpenSans-Bold.ttf */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = file; name = "OpenSans-Bold.ttf"; path = "WordPress-iOS-Shared/Assets/OpenSans-Bold.ttf"; sourceTree = "<group>"; };
+		36944359AB06987437512C83 /* UIImage+Util.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIImage+Util.m"; path = "WordPress-iOS-Shared/Core/UIImage+Util.m"; sourceTree = "<group>"; };
+		372E7D52FF1C08DF33E55661 /* Pods-EditorDemo-NSObject-SafeExpectations-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-EditorDemo-NSObject-SafeExpectations-dummy.m"; sourceTree = "<group>"; };
+		37AAC3B7B3A2C70273F4B3D2 /* NSDictionary+SafeExpectations.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "NSDictionary+SafeExpectations.m"; sourceTree = "<group>"; };
+		37FA504A49AC5684EF946CBD /* AFHTTPRequestOperationManager.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AFHTTPRequestOperationManager.m; path = AFNetworking/AFHTTPRequestOperationManager.m; sourceTree = "<group>"; };
+		3854677C9837813EB95CF05B /* Podfile */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
+		39A6D2B1D31F514BE1BCB543 /* WPTableViewCell.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = WPTableViewCell.m; path = "WordPress-iOS-Shared/Core/WPTableViewCell.m"; sourceTree = "<group>"; };
+		3B01E0BF692F74633041F2C8 /* ZSStextcolor@2x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = "ZSStextcolor@2x.png"; sourceTree = "<group>"; };
+		3E468D9FFDAE323AC5151DE2 /* AFURLRequestSerialization.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AFURLRequestSerialization.h; path = AFNetworking/AFURLRequestSerialization.h; sourceTree = "<group>"; };
+		3E6FC2D20653D35A47ABB183 /* UIButton+AFNetworking.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIButton+AFNetworking.h"; path = "UIKit+AFNetworking/UIButton+AFNetworking.h"; sourceTree = "<group>"; };
+		3ED80500DFCEC27F4AE8C221 /* WPTableViewSectionHeaderView.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = WPTableViewSectionHeaderView.m; path = "WordPress-iOS-Shared/Core/WPTableViewSectionHeaderView.m"; sourceTree = "<group>"; };
+		3F5A6E8E30BFB77E50AE57EE /* DDTTYLogger.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = DDTTYLogger.h; path = Classes/DDTTYLogger.h; sourceTree = "<group>"; };
+		3FC7FAE84FBA1C2DC3791B12 /* DDLog.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = DDLog.m; path = Classes/DDLog.m; sourceTree = "<group>"; };
+		3FDA9FF74C52D9ECF0E91763 /* Pods-EditorDemoTests-CocoaLumberjack-Private.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-EditorDemoTests-CocoaLumberjack-Private.xcconfig"; path = "../Pods-EditorDemoTests-CocoaLumberjack/Pods-EditorDemoTests-CocoaLumberjack-Private.xcconfig"; sourceTree = "<group>"; };
+		408293AB03EE4D0333F59F94 /* WPLegacyEditorViewController.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = WPLegacyEditorViewController.h; sourceTree = "<group>"; };
+		4136FEC8DF0711065CDF11DC /* WPLegacyKeyboardToolbarBase.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = WPLegacyKeyboardToolbarBase.m; sourceTree = "<group>"; };
+		420D65E0EAB5DFA8861D01FB /* WPEditorView.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = WPEditorView.m; sourceTree = "<group>"; };
+		42A02C404A0FB82B3E225C21 /* NSString+Util.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSString+Util.h"; path = "WordPress-iOS-Shared/Core/NSString+Util.h"; sourceTree = "<group>"; };
+		43E12506949E3528076FD742 /* WPImageSource.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = WPImageSource.h; path = "WordPress-iOS-Shared/Core/WPImageSource.h"; sourceTree = "<group>"; };
+		44CA4CDDD7EDD50E21DED3DF /* icon_preview.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = icon_preview.png; sourceTree = "<group>"; };
+		44DC9BF94D0FCA6892703CC3 /* Merriweather-Bold.ttf */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = file; name = "Merriweather-Bold.ttf"; path = "WordPress-iOS-Shared/Assets/Merriweather-Bold.ttf"; sourceTree = "<group>"; };
+		459E24005B62319A7867BFB3 /* DDLog.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = DDLog.h; path = Classes/DDLog.h; sourceTree = "<group>"; };
+		461E47229FF250FB9C85BDDF /* WPLegacyKeyboardToolbarBase.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = WPLegacyKeyboardToolbarBase.h; sourceTree = "<group>"; };
+		462A898F904BC55A27F74B98 /* icon_format_quote@2x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = "icon_format_quote@2x.png"; sourceTree = "<group>"; };
+		46F9C8EB1564CC02D7BE58F5 /* Pods-EditorDemo-WordPressCom-Analytics-iOS-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-EditorDemo-WordPressCom-Analytics-iOS-dummy.m"; sourceTree = "<group>"; };
+		470F24E815401928FD955EB3 /* icon_format_bold@2x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = "icon_format_bold@2x.png"; sourceTree = "<group>"; };
+		49950677A0673A43329414AE /* DDASLLogCapture.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = DDASLLogCapture.m; path = Classes/DDASLLogCapture.m; sourceTree = "<group>"; };
+		4BDE5D7F2637C29BC2E2C79D /* icon_format_keyboard.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = icon_format_keyboard.png; sourceTree = "<group>"; };
+		4C42ED855F0AE2EDAA16A5D8 /* UIRefreshControl+AFNetworking.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIRefreshControl+AFNetworking.m"; path = "UIKit+AFNetworking/UIRefreshControl+AFNetworking.m"; sourceTree = "<group>"; };
+		4C6F28CA3F79CD33878D4A2A /* HRCgUtil.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = HRCgUtil.h; sourceTree = "<group>"; };
+		4C86F7989DFF3E0ACF0B5353 /* Merriweather-LightItalic.otf */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = file; name = "Merriweather-LightItalic.otf"; path = "WordPress-iOS-Shared/Assets/Merriweather-LightItalic.otf"; sourceTree = "<group>"; };
+		4DC9D69691F2040AE1AE5DC7 /* icon_format_media.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = icon_format_media.png; sourceTree = "<group>"; };
+		4E315DF24D4044B7F83F9CEB /* icon_format_quote@3x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = "icon_format_quote@3x.png"; sourceTree = "<group>"; };
+		5003CDF4976CB62213B55E95 /* ZSSBarButtonItem.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = ZSSBarButtonItem.h; sourceTree = "<group>"; };
+		5014F8280E10445967428D5E /* HRCgUtil.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = HRCgUtil.m; sourceTree = "<group>"; };
+		50339097B8CBC5E886B6D725 /* ZSSindent.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = ZSSindent.png; sourceTree = "<group>"; };
+		507B500CC9F77BA3A2B0914F /* rangy-classapplier.js */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.javascript; path = "rangy-classapplier.js"; sourceTree = "<group>"; };
+		508CF2FF147199EDE0723309 /* icon-posts-editor-inspector@2x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = "icon-posts-editor-inspector@2x.png"; sourceTree = "<group>"; };
+		50A6753DC213E299ED70D9B2 /* icon_format_link@2x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = "icon_format_link@2x.png"; sourceTree = "<group>"; };
+		53792216D7D30CEB563A411E /* icon-posts-editor-preview@2x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = "icon-posts-editor-preview@2x.png"; sourceTree = "<group>"; };
+		538275645AFBCEE7FF7065A1 /* CYRToken.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = CYRToken.h; sourceTree = "<group>"; };
+		558641644DB1BF02BEB5DC0F /* AFURLResponseSerialization.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AFURLResponseSerialization.m; path = AFNetworking/AFURLResponseSerialization.m; sourceTree = "<group>"; };
+		56611B202B6287B13093772B /* libPods-EditorDemo-UIAlertView+Blocks.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-EditorDemo-UIAlertView+Blocks.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		57B573EE6EE4B8A2D1AB2638 /* ZSSh1@2x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = "ZSSh1@2x.png"; sourceTree = "<group>"; };
+		58A390AA3878ED244AF4145F /* UIAlertView+AFNetworking.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIAlertView+AFNetworking.h"; path = "UIKit+AFNetworking/UIAlertView+AFNetworking.h"; sourceTree = "<group>"; };
+		59CFC3C3787398193949FD23 /* ZSSsubscript.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = ZSSsubscript.png; sourceTree = "<group>"; };
+		5B2680213E17A1E146706669 /* WPAnalytics.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = WPAnalytics.m; path = "WordPressCom-Analytics-iOS/WPAnalytics.m"; sourceTree = "<group>"; };
+		5B62FE1DB620BA0F7EC28E47 /* Merriweather-Light.ttf */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = file; name = "Merriweather-Light.ttf"; path = "WordPress-iOS-Shared/Assets/Merriweather-Light.ttf"; sourceTree = "<group>"; };
+		5F5C0A4D9CAF7343AC166722 /* libPods-EditorDemo-NSObject-SafeExpectations.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-EditorDemo-NSObject-SafeExpectations.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		5FC5BB613559A5EF42318132 /* NSString+Util.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSString+Util.m"; path = "WordPress-iOS-Shared/Core/NSString+Util.m"; sourceTree = "<group>"; };
+		605D515A3EF49FA9807F52E2 /* UIKit+AFNetworking.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIKit+AFNetworking.h"; path = "UIKit+AFNetworking/UIKit+AFNetworking.h"; sourceTree = "<group>"; };
+		60D844A00647ED2C3508F964 /* ZSSh3.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = ZSSh3.png; sourceTree = "<group>"; };
+		61006414E39A528C4E58750D /* ZSShorizontalrule@2x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = "ZSShorizontalrule@2x.png"; sourceTree = "<group>"; };
+		617E743CCBD34CC14239ED5F /* libPods-EditorDemo-WordPressCom-Analytics-iOS.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-EditorDemo-WordPressCom-Analytics-iOS.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		618C257A9F2380A5ABE4F155 /* ZSSleftjustify@2x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = "ZSSleftjustify@2x.png"; sourceTree = "<group>"; };
+		61E0D674159B1D208B6ABAD8 /* ZSSoutdent.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = ZSSoutdent.png; sourceTree = "<group>"; };
+		62DB79E852F20BF71B5EA023 /* WPStyleGuide.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = WPStyleGuide.m; path = "WordPress-iOS-Shared/Core/WPStyleGuide.m"; sourceTree = "<group>"; };
+		64F72B8A17254D806052C879 /* AFURLSessionManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AFURLSessionManager.h; path = AFNetworking/AFURLSessionManager.h; sourceTree = "<group>"; };
+		6550526B8CFC8CDCE4485C85 /* WPTableViewSectionHeaderView.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = WPTableViewSectionHeaderView.h; path = "WordPress-iOS-Shared/Core/WPTableViewSectionHeaderView.h"; sourceTree = "<group>"; };
+		6852C355F0448E78E1B00E85 /* Pods-EditorDemo-WordPressCom-Analytics-iOS.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-EditorDemo-WordPressCom-Analytics-iOS.xcconfig"; sourceTree = "<group>"; };
+		6992D1169C726D17CA37099F /* icon_format_underline@2x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = "icon_format_underline@2x.png"; sourceTree = "<group>"; };
+		69CCB1A9A961BE8BC09AB9F3 /* ZSSh4@2x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = "ZSSh4@2x.png"; sourceTree = "<group>"; };
+		69E26CA56F380BD51A9A5780 /* HRColorPickerView.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = HRColorPickerView.m; sourceTree = "<group>"; };
+		6A98ABB91F55F02BCDFEF6BA /* Pods-EditorDemo.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-EditorDemo.debug.xcconfig"; sourceTree = "<group>"; };
+		6B5871EF1DB454680B239044 /* WPImageMeta.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = WPImageMeta.h; sourceTree = "<group>"; };
+		6C1DD8384513A2FD9BB9C2AE /* WPEditorField.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = WPEditorField.m; sourceTree = "<group>"; };
+		6C955FC153161B3415581076 /* icon_format_media@3x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = "icon_format_media@3x.png"; sourceTree = "<group>"; };
+		6D533419F7F6ACD8998B4A9E /* icon_format_unlink.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = icon_format_unlink.png; sourceTree = "<group>"; };
+		6E8DC67E9E5090F63319260D /* AFNetworkReachabilityManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AFNetworkReachabilityManager.h; path = AFNetworking/AFNetworkReachabilityManager.h; sourceTree = "<group>"; };
+		6F9D799883EEAFA57E678C3F /* DDAbstractDatabaseLogger.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = DDAbstractDatabaseLogger.h; path = Classes/DDAbstractDatabaseLogger.h; sourceTree = "<group>"; };
+		70967CF7678EDC88A3D32E0F /* WPEditorToolbarButton.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = WPEditorToolbarButton.h; sourceTree = "<group>"; };
+		723BC3DF7F0C51B0FAA1836E /* icon_format_strikethrough@2x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = "icon_format_strikethrough@2x.png"; sourceTree = "<group>"; };
+		7334EA17018B09751A95A371 /* WPNoResultsView.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = WPNoResultsView.m; path = "WordPress-iOS-Shared/Core/WPNoResultsView.m"; sourceTree = "<group>"; };
+		737A955B6AB464B3A2DEECD7 /* DDAssertMacros.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = DDAssertMacros.h; path = Classes/DDAssertMacros.h; sourceTree = "<group>"; };
+		74442FB3EEB4B3483B2DE99F /* HRBrightnessCursor.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = HRBrightnessCursor.h; sourceTree = "<group>"; };
+		749D6965D9B4AC4956B45D4A /* HRColorPickerViewController.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = HRColorPickerViewController.m; sourceTree = "<group>"; };
+		75C887F2FFC0C86B017A0ADB /* ZSSTextView.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = ZSSTextView.m; sourceTree = "<group>"; };
+		75CEEE89768D66DEAD93AAB8 /* wpload.js */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.javascript; path = wpload.js; sourceTree = "<group>"; };
+		75E48F1669F5240C37D42CD0 /* HRBrightnessCursor.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = HRBrightnessCursor.m; sourceTree = "<group>"; };
+		7681897CF50837832FE2299B /* ZSSTextView.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = ZSSTextView.h; sourceTree = "<group>"; };
+		76BDC2FCBC2BA88FB97A16C5 /* HRColorCursor.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = HRColorCursor.m; sourceTree = "<group>"; };
+		77241CD57509022AF218143E /* DDDispatchQueueLogFormatter.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = DDDispatchQueueLogFormatter.h; path = Classes/Extensions/DDDispatchQueueLogFormatter.h; sourceTree = "<group>"; };
+		7754A6100490930D0A6F22A2 /* NSDictionary+SafeExpectations.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "NSDictionary+SafeExpectations.h"; sourceTree = "<group>"; };
+		7A17FE572B152A4B1AFCC6EF /* WPEditorViewController.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = WPEditorViewController.m; sourceTree = "<group>"; };
+		7A4CAA54E3B816D1E4362729 /* UITableViewTextFieldCell.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = UITableViewTextFieldCell.h; path = "WordPress-iOS-Shared/Core/UITableViewTextFieldCell.h"; sourceTree = "<group>"; };
+		7B4BEB1ED0D87B02894A937B /* AFURLConnectionOperation.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AFURLConnectionOperation.h; path = AFNetworking/AFURLConnectionOperation.h; sourceTree = "<group>"; };
+		7BBE9E4C1D09B1398C3EB085 /* WordPress-iOS-Shared.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "WordPress-iOS-Shared.bundle"; sourceTree = BUILT_PRODUCTS_DIR; };
+		7CB2348B9191FFBAF446C505 /* WPFontManager.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = WPFontManager.m; path = "WordPress-iOS-Shared/Core/WPFontManager.m"; sourceTree = "<group>"; };
+		7E40A3436DCC6C41C855EF10 /* AFNetworkReachabilityManager.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AFNetworkReachabilityManager.m; path = AFNetworking/AFNetworkReachabilityManager.m; sourceTree = "<group>"; };
+		7EBA66A1BD335B70B21AF8D3 /* OpenSans-Semibold.ttf */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = file; name = "OpenSans-Semibold.ttf"; path = "WordPress-iOS-Shared/Assets/OpenSans-Semibold.ttf"; sourceTree = "<group>"; };
+		7F04CE6130A817BDD0CD1801 /* libPods-EditorDemo-WordPress-iOS-Editor.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-EditorDemo-WordPress-iOS-Editor.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		7F53F9D8EB84F95DEE41E54D /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS8.3.sdk/System/Library/Frameworks/Security.framework; sourceTree = DEVELOPER_DIR; };
+		80302E9B4537ECB6EF286F65 /* ZSSh6.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = ZSSh6.png; sourceTree = "<group>"; };
+		804362E3A200B38A7E623C87 /* Pods-EditorDemo-NSObject-SafeExpectations-Private.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-EditorDemo-NSObject-SafeExpectations-Private.xcconfig"; sourceTree = "<group>"; };
+		80C3BFD36B90F05B774A99D7 /* ZSSclearstyle@2x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = "ZSSclearstyle@2x.png"; sourceTree = "<group>"; };
+		81A89E9F59F0D078E8D4E90F /* ZSScenterjustify.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = ZSScenterjustify.png; sourceTree = "<group>"; };
+		830D29E461F607EF9E618A7D /* AFNetworking.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AFNetworking.h; path = AFNetworking/AFNetworking.h; sourceTree = "<group>"; };
+		83D6D3668F3C091493AE9921 /* WPLegacyKeyboardToolbarButtonItem.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = WPLegacyKeyboardToolbarButtonItem.m; sourceTree = "<group>"; };
+		83E63C23734D05C5F7D84FFB /* icon_format_keyboard@2x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = "icon_format_keyboard@2x.png"; sourceTree = "<group>"; };
+		845A813DEB80571DF4A6253A /* icon_format_more.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = icon_format_more.png; sourceTree = "<group>"; };
+		849E16B8E6FBAD38FBBB605A /* Merriweather-BoldItalic.otf */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = file; name = "Merriweather-BoldItalic.otf"; path = "WordPress-iOS-Shared/Assets/Merriweather-BoldItalic.otf"; sourceTree = "<group>"; };
+		856DAB3458CD20E190080D02 /* ZSSclearstyle.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = ZSSclearstyle.png; sourceTree = "<group>"; };
+		8673BA9704033A8EDE356D91 /* AFHTTPRequestOperation.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AFHTTPRequestOperation.h; path = AFNetworking/AFHTTPRequestOperation.h; sourceTree = "<group>"; };
+		88D1C5871925C98B76AC8B91 /* icon_options@2x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = "icon_options@2x.png"; sourceTree = "<group>"; };
+		89178CA53DE5E6AADB6E2DC8 /* WPAnalytics.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = WPAnalytics.h; path = "WordPressCom-Analytics-iOS/WPAnalytics.h"; sourceTree = "<group>"; };
+		8BF2AD80274A9014FCDA0179 /* icon_format_html.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = icon_format_html.png; sourceTree = "<group>"; };
+		8C4B50D9E38CB0C5DC4C6E52 /* libPods-EditorDemo-AFNetworking.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-EditorDemo-AFNetworking.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		8D2907D3E03FDD35B890C6EB /* WPTableViewCell.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = WPTableViewCell.h; path = "WordPress-iOS-Shared/Core/WPTableViewCell.h"; sourceTree = "<group>"; };
+		8DD9BC7FDB3B0355D30E9E0D /* ZSSleftjustify.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = ZSSleftjustify.png; sourceTree = "<group>"; };
+		8E0332AA34CBB34D2AA96BE8 /* ZSSoutdent@2x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = "ZSSoutdent@2x.png"; sourceTree = "<group>"; };
+		8EFE5084F4569412038D7BF7 /* ZSSh3@2x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = "ZSSh3@2x.png"; sourceTree = "<group>"; };
+		8F49C8748333FFF4261DECC6 /* ZSSh4.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = ZSSh4.png; sourceTree = "<group>"; };
+		9042126015EA1889026A8E54 /* ZSSh5@2x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = "ZSSh5@2x.png"; sourceTree = "<group>"; };
+		90FD1475E81FF37A85C5BF31 /* WPEditorLoggingConfiguration.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = WPEditorLoggingConfiguration.m; sourceTree = "<group>"; };
+		91AA5F7A46E7DCF32B6B87FD /* rangy-selectionsaverestore.js */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.javascript; path = "rangy-selectionsaverestore.js"; sourceTree = "<group>"; };
+		91ABD55B7DDE2A9FE545EFFE /* ZSSforcejustify.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = ZSSforcejustify.png; sourceTree = "<group>"; };
+		9240B509809EAFE71B4FC987 /* rangy-highlighter.js */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.javascript; path = "rangy-highlighter.js"; sourceTree = "<group>"; };
+		92734290DB026F15AF179C9A /* WPTableViewSectionFooterView.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = WPTableViewSectionFooterView.m; path = "WordPress-iOS-Shared/Core/WPTableViewSectionFooterView.m"; sourceTree = "<group>"; };
+		940F4A009B6C35A94B00B390 /* AFHTTPSessionManager.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AFHTTPSessionManager.m; path = AFNetworking/AFHTTPSessionManager.m; sourceTree = "<group>"; };
+		94393AB1696E6A7F79B8DFAF /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS8.3.sdk/System/Library/Frameworks/CoreGraphics.framework; sourceTree = DEVELOPER_DIR; };
+		94424D69775A77CFB3BD44C9 /* libPods-EditorDemoTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-EditorDemoTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		955EA642B62D7FA7676DB7D7 /* icon_format_bold@3x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = "icon_format_bold@3x.png"; sourceTree = "<group>"; };
+		97B98167D74764B5BDACB9AD /* icon_format_bold.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = icon_format_bold.png; sourceTree = "<group>"; };
+		98293A40B63B4D47CA75A7AE /* Pods-EditorDemo-environment.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-EditorDemo-environment.h"; sourceTree = "<group>"; };
+		9842E60B14C6412B7366C96C /* ZSSh6@2x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = "ZSSh6@2x.png"; sourceTree = "<group>"; };
+		9900653897AC272CF5E46CE7 /* icon_format_link.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = icon_format_link.png; sourceTree = "<group>"; };
+		9A59A5E80A2B8C1880C06910 /* Pods-EditorDemo-UIAlertView+Blocks.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-EditorDemo-UIAlertView+Blocks.xcconfig"; sourceTree = "<group>"; };
+		9B18C48B89649646EFFEC8EE /* icon-posts-editor-inspector@3x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = "icon-posts-editor-inspector@3x.png"; sourceTree = "<group>"; };
+		9B32D85834184C4D9047C37D /* NSString+XMLExtensions.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSString+XMLExtensions.m"; path = "WordPress-iOS-Shared/Core/NSString+XMLExtensions.m"; sourceTree = "<group>"; };
+		9C58B70512F65A1952BBB06D /* icon_format_ol@3x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = "icon_format_ol@3x.png"; sourceTree = "<group>"; };
+		A04E1DC754C74A9AFAF22576 /* WPDeviceIdentification.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = WPDeviceIdentification.m; path = "WordPress-iOS-Shared/Core/WPDeviceIdentification.m"; sourceTree = "<group>"; };
+		A09C046F3AA114F182E3CE20 /* icon_format_ol@2x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = "icon_format_ol@2x.png"; sourceTree = "<group>"; };
+		A0F250D3BB9218077B8EBF56 /* ZSSrightjustify.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = ZSSrightjustify.png; sourceTree = "<group>"; };
+		A1F9A0588FF6B5D8B2BDEDB3 /* Pods-EditorDemo-AFNetworking-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-EditorDemo-AFNetworking-prefix.pch"; sourceTree = "<group>"; };
+		A202938EC1CAF9A2894E9DD0 /* Pods-EditorDemo-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-EditorDemo-dummy.m"; sourceTree = "<group>"; };
+		A23AF990EA8E1465C5EA2792 /* DDFileLogger.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = DDFileLogger.m; path = Classes/DDFileLogger.m; sourceTree = "<group>"; };
+		A256E763365F8356EFA37C3C /* rangy-core.js */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.javascript; path = "rangy-core.js"; sourceTree = "<group>"; };
+		A2F7B749D27EDAD85F31094B /* Pods-EditorDemo-CocoaLumberjack-Private.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-EditorDemo-CocoaLumberjack-Private.xcconfig"; sourceTree = "<group>"; };
+		A3667D4368AC7BD98AB11EBE /* WPLegacyKeyboardToolbarButtonItem.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = WPLegacyKeyboardToolbarButtonItem.h; sourceTree = "<group>"; };
+		A432A3184956447B5213C54D /* icon_format_italic.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = icon_format_italic.png; sourceTree = "<group>"; };
+		A46A377BA1C610606899CC71 /* Pods-EditorDemo-WordPress-iOS-Editor-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-EditorDemo-WordPress-iOS-Editor-prefix.pch"; sourceTree = "<group>"; };
+		A5B427F064254477FBBD5E6D /* Merriweather-Regular.ttf */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = file; name = "Merriweather-Regular.ttf"; path = "WordPress-iOS-Shared/Assets/Merriweather-Regular.ttf"; sourceTree = "<group>"; };
+		A5CAF1034DE3F578EB766D29 /* WPEditorToolbarView.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = WPEditorToolbarView.m; sourceTree = "<group>"; };
+		A6D0FB35913872011A176B84 /* WPLegacyKeyboardToolbarDone.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = WPLegacyKeyboardToolbarDone.h; sourceTree = "<group>"; };
+		A7D25E3367BF6BD686EFE36B /* Pods-EditorDemo-UIAlertView+Blocks-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-EditorDemo-UIAlertView+Blocks-prefix.pch"; sourceTree = "<group>"; };
+		A7D62E2AEE9F4BDDAF121FB7 /* HRColorPickerView.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = HRColorPickerView.h; sourceTree = "<group>"; };
+		A880B57A5429CEF2C758AC91 /* ZSSh1.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = ZSSh1.png; sourceTree = "<group>"; };
+		A8AE6EAD9DC1D6E0427A7141 /* Pods-EditorDemo-AFNetworking-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-EditorDemo-AFNetworking-dummy.m"; sourceTree = "<group>"; };
+		AA1A34EBC1C052DDD1904412 /* WPEditorToolbarButton.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = WPEditorToolbarButton.m; sourceTree = "<group>"; };
+		AB5CEF469BB8828385E8B670 /* libPods-EditorDemo-WordPress-iOS-Shared.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-EditorDemo-WordPress-iOS-Shared.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		AC43F877A2A01161D907B6D8 /* Pods-EditorDemoTests-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-EditorDemoTests-acknowledgements.markdown"; sourceTree = "<group>"; };
+		B0DA4757DEBA061F8BEA5C90 /* CYRTextView.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = CYRTextView.h; sourceTree = "<group>"; };
+		B11EEE44A00709A906D350E0 /* DDContextFilterLogFormatter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = DDContextFilterLogFormatter.m; path = Classes/Extensions/DDContextFilterLogFormatter.m; sourceTree = "<group>"; };
+		B15945148F4AEB9DBDB51856 /* UIWebView+GUIFixes.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "UIWebView+GUIFixes.h"; sourceTree = "<group>"; };
+		B163A43834E87052599E6D53 /* HRColorUtil.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = HRColorUtil.m; sourceTree = "<group>"; };
+		B1A4B03D05F71C61BD430F79 /* OpenSans-Regular.ttf */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = file; name = "OpenSans-Regular.ttf"; path = "WordPress-iOS-Shared/Assets/OpenSans-Regular.ttf"; sourceTree = "<group>"; };
+		B2445A05A99FF8B7B37E9A00 /* Pods-EditorDemo-WordPress-iOS-Shared-Private.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-EditorDemo-WordPress-iOS-Shared-Private.xcconfig"; sourceTree = "<group>"; };
+		B2C72AB408256C2ED5FCABE4 /* ZSSredo@2x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = "ZSSredo@2x.png"; sourceTree = "<group>"; };
+		B422F6762B690B55C1EC79AA /* AFURLSessionManager.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AFURLSessionManager.m; path = AFNetworking/AFURLSessionManager.m; sourceTree = "<group>"; };
+		B47F30258990ECA0D498A47A /* DDFileLogger.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = DDFileLogger.h; path = Classes/DDFileLogger.h; sourceTree = "<group>"; };
+		B601337600D2A5E61998CB85 /* jquery.js */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.javascript; path = jquery.js; sourceTree = "<group>"; };
+		B899899B2D176B9218A6EEE0 /* icon_format_ol.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = icon_format_ol.png; sourceTree = "<group>"; };
+		B90BD7F531876B3FF3B4C90E /* ZSSsuperscript@2x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = "ZSSsuperscript@2x.png"; sourceTree = "<group>"; };
+		B9384D5F417CF854217CB608 /* Pods-EditorDemo-WordPress-iOS-Editor.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-EditorDemo-WordPress-iOS-Editor.xcconfig"; sourceTree = "<group>"; };
+		B97B1EE3D83CF6F0BBAD6C5B /* UIImage+Util.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIImage+Util.h"; path = "WordPress-iOS-Shared/Core/UIImage+Util.h"; sourceTree = "<group>"; };
+		B9DA7B876D2652FCDAB214CA /* Pods-EditorDemo-WordPress-iOS-Editor-Private.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-EditorDemo-WordPress-iOS-Editor-Private.xcconfig"; sourceTree = "<group>"; };
+		BA62D90FEA53B27B7AE7B24F /* ZSScenterjustify@2x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = "ZSScenterjustify@2x.png"; sourceTree = "<group>"; };
+		BBA4062FEA14CA197DA5B036 /* UIButton+AFNetworking.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIButton+AFNetworking.m"; path = "UIKit+AFNetworking/UIButton+AFNetworking.m"; sourceTree = "<group>"; };
+		BE75D030229DE640D09F07F8 /* ZSSsubscript@2x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = "ZSSsubscript@2x.png"; sourceTree = "<group>"; };
+		BFF4FBE75092CC85C45662DD /* DDTTYLogger.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = DDTTYLogger.m; path = Classes/DDTTYLogger.m; sourceTree = "<group>"; };
+		C045E87560C5D5C18C9E4348 /* ZSSindent@2x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = "ZSSindent@2x.png"; sourceTree = "<group>"; };
+		C103205F3A38A1AFDF27C83C /* Pods-EditorDemo-WordPress-iOS-Editor-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-EditorDemo-WordPress-iOS-Editor-dummy.m"; sourceTree = "<group>"; };
+		C1B9353D016D5F5C1CD1488B /* ZSSbgcolor@2x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = "ZSSbgcolor@2x.png"; sourceTree = "<group>"; };
+		C4AF95B320D7BBEADEB26E1C /* icon_format_html@3x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = "icon_format_html@3x.png"; sourceTree = "<group>"; };
+		C4D86EFAE2EDA6F2B3557225 /* CYRTextView.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = CYRTextView.m; sourceTree = "<group>"; };
+		C55B74F70932078898621BEB /* OpenSans-BoldItalic.ttf */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = file; name = "OpenSans-BoldItalic.ttf"; path = "WordPress-iOS-Shared/Assets/OpenSans-BoldItalic.ttf"; sourceTree = "<group>"; };
+		C55D8A64C4DE697A38F55CD6 /* Pods-EditorDemo-NSObject-SafeExpectations-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-EditorDemo-NSObject-SafeExpectations-prefix.pch"; sourceTree = "<group>"; };
+		C5B61413E187F9BC0C37CEE1 /* WPImageMeta.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = WPImageMeta.m; sourceTree = "<group>"; };
+		C5FBE421BE6715DE7A8087E9 /* Pods-EditorDemo-WordPressCom-Analytics-iOS-Private.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-EditorDemo-WordPressCom-Analytics-iOS-Private.xcconfig"; sourceTree = "<group>"; };
+		C6805C816ED05AC8A28D47E4 /* AFURLRequestSerialization.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AFURLRequestSerialization.m; path = AFNetworking/AFURLRequestSerialization.m; sourceTree = "<group>"; };
+		C6953FD23C17AD12497FBB0F /* DDLegacyMacros.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = DDLegacyMacros.h; path = Classes/DDLegacyMacros.h; sourceTree = "<group>"; };
+		C72782E3AFB1B33B1F0EB082 /* CocoaLumberjack.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = CocoaLumberjack.h; path = Classes/CocoaLumberjack.h; sourceTree = "<group>"; };
+		C74F3D313646F7D2310B5F81 /* libPods-EditorDemo-CocoaLumberjack.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-EditorDemo-CocoaLumberjack.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		C83A43068A5FFDDFCA024565 /* HRColorPickerMacros.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = HRColorPickerMacros.h; sourceTree = "<group>"; };
+		C8484604FD3033710AB6DE62 /* WPDeviceIdentification.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = WPDeviceIdentification.h; path = "WordPress-iOS-Shared/Core/WPDeviceIdentification.h"; sourceTree = "<group>"; };
+		C8F378A41CF4CCD2565AA20A /* CYRLayoutManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = CYRLayoutManager.h; sourceTree = "<group>"; };
+		C94387FAC53D4EF4B2DDDAE4 /* UIProgressView+AFNetworking.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIProgressView+AFNetworking.h"; path = "UIKit+AFNetworking/UIProgressView+AFNetworking.h"; sourceTree = "<group>"; };
+		C986ECA9682A194B494E39FD /* WPNoResultsView.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = WPNoResultsView.h; path = "WordPress-iOS-Shared/Core/WPNoResultsView.h"; sourceTree = "<group>"; };
+		CC9D574E384F52B696DE17D8 /* icon_format_italic@2x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = "icon_format_italic@2x.png"; sourceTree = "<group>"; };
+		CCD50474AD55C76E4C71F5C6 /* UIProgressView+AFNetworking.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIProgressView+AFNetworking.m"; path = "UIKit+AFNetworking/UIProgressView+AFNetworking.m"; sourceTree = "<group>"; };
+		CDA3414F53DB1756DB583319 /* ZSSsuperscript.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = ZSSsuperscript.png; sourceTree = "<group>"; };
+		D1FBB843E22CF9F8D635CF8D /* ZSSundo.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = ZSSundo.png; sourceTree = "<group>"; };
+		D3B1F964851055DB409A90BB /* Pods-EditorDemoTests-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-EditorDemoTests-dummy.m"; sourceTree = "<group>"; };
+		D433D2E8A688F8A9CAFFB415 /* Pods-EditorDemo-CocoaLumberjack-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-EditorDemo-CocoaLumberjack-dummy.m"; sourceTree = "<group>"; };
+		D58823FC4526B2C3BC865271 /* shortcode.js */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.javascript; path = shortcode.js; sourceTree = "<group>"; };
+		D5B41411BF9D5EF07E5B975D /* UITableViewTextFieldCell.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = UITableViewTextFieldCell.m; path = "WordPress-iOS-Shared/Core/UITableViewTextFieldCell.m"; sourceTree = "<group>"; };
+		D650A0A75C9D9C5AAB53A554 /* icon_format_ul@2x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = "icon_format_ul@2x.png"; sourceTree = "<group>"; };
+		D8533A19FBA3CA1A2209E485 /* Pods-EditorDemo-UIAlertView+Blocks-Private.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-EditorDemo-UIAlertView+Blocks-Private.xcconfig"; sourceTree = "<group>"; };
+		D8AF1A872FF52CB9CD476958 /* UIWebView+AFNetworking.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIWebView+AFNetworking.h"; path = "UIKit+AFNetworking/UIWebView+AFNetworking.h"; sourceTree = "<group>"; };
+		D90FF56905C99BB94F84E117 /* Pods-EditorDemo-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-EditorDemo-acknowledgements.markdown"; sourceTree = "<group>"; };
+		D986604F98202B97779F9A36 /* underscore-min.js */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.javascript; path = "underscore-min.js"; sourceTree = "<group>"; };
+		DA1ABCA6BB1A3811A9EC9985 /* ZSSRichTextEditor.js */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.javascript; path = ZSSRichTextEditor.js; sourceTree = "<group>"; };
+		DBEC760F3CC8F9204DB95D6D /* ZSSrightjustify@2x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = "ZSSrightjustify@2x.png"; sourceTree = "<group>"; };
+		DC187FBCD9C194FA06A35129 /* AFHTTPRequestOperationManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = AFHTTPRequestOperationManager.h; path = AFNetworking/AFHTTPRequestOperationManager.h; sourceTree = "<group>"; };
+		DEB52D0CD09739AEE7E3DAC3 /* ZSSredo.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = ZSSredo.png; sourceTree = "<group>"; };
+		DF0EE4D20EF36C3B74332D25 /* WPFontManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = WPFontManager.h; path = "WordPress-iOS-Shared/Core/WPFontManager.h"; sourceTree = "<group>"; };
+		DF1935770CBFEFA76E573974 /* jquery.mobile-events.min.js */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.javascript; path = "jquery.mobile-events.min.js"; sourceTree = "<group>"; };
+		E008A051AE16697FBF99938F /* Merriweather-Italic.otf */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = file; name = "Merriweather-Italic.otf"; path = "WordPress-iOS-Shared/Assets/Merriweather-Italic.otf"; sourceTree = "<group>"; };
+		E0B8D2BA2411BE41144FF737 /* CYRTextStorage.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = CYRTextStorage.m; sourceTree = "<group>"; };
+		E0C5151DF40930A4D47E94E8 /* rangy-serializer.js */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.javascript; path = "rangy-serializer.js"; sourceTree = "<group>"; };
+		E0CB942B52E318E6F4317D9E /* Pods-EditorDemoTests-CocoaLumberjack.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-EditorDemoTests-CocoaLumberjack.xcconfig"; path = "../Pods-EditorDemoTests-CocoaLumberjack/Pods-EditorDemoTests-CocoaLumberjack.xcconfig"; sourceTree = "<group>"; };
+		E0D406C0EB0F7A314F8E4706 /* icon_format_quote.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = icon_format_quote.png; sourceTree = "<group>"; };
+		E27B8D0B439915F8D923D746 /* WPAnimatedImageResponseSerializer.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = WPAnimatedImageResponseSerializer.m; path = "WordPress-iOS-Shared/Core/WPAnimatedImageResponseSerializer.m"; sourceTree = "<group>"; };
+		E2A1D7EC00921340BB6617F9 /* icon_preview@2x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = "icon_preview@2x.png"; sourceTree = "<group>"; };
+		E3A69BFB86F47ADB12091BB6 /* UIImageView+AFNetworking.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIImageView+AFNetworking.h"; path = "UIKit+AFNetworking/UIImageView+AFNetworking.h"; sourceTree = "<group>"; };
+		E445EAD7079FB1D560FA0FCB /* icon_options.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = icon_options.png; sourceTree = "<group>"; };
+		E523C7CAD67485E52A339467 /* NSString+XMLExtensions.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSString+XMLExtensions.h"; path = "WordPress-iOS-Shared/Core/NSString+XMLExtensions.h"; sourceTree = "<group>"; };
+		E5A3AA62FF0A85993BC8A5F0 /* Pods-EditorDemo-NSObject-SafeExpectations.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-EditorDemo-NSObject-SafeExpectations.xcconfig"; sourceTree = "<group>"; };
+		E5F5019259C6F329D71795FC /* WPAnimatedImageResponseSerializer.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = WPAnimatedImageResponseSerializer.h; path = "WordPress-iOS-Shared/Core/WPAnimatedImageResponseSerializer.h"; sourceTree = "<group>"; };
+		E667E8C13719F24F6E718AD9 /* HRColorUtil.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = HRColorUtil.h; sourceTree = "<group>"; };
+		E7C27BA430080E70025E12CD /* DDASLLogCapture.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = DDASLLogCapture.h; path = Classes/DDASLLogCapture.h; sourceTree = "<group>"; };
+		E7E9E00054084C2BD9AE08A6 /* ZSSBarButtonItem.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = ZSSBarButtonItem.m; sourceTree = "<group>"; };
+		E8A4B42045977FD8F38D2E48 /* WPEditorField.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = WPEditorField.h; sourceTree = "<group>"; };
+		EAC99E4AE0F997449AD088F4 /* AFNetworkActivityIndicatorManager.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = AFNetworkActivityIndicatorManager.m; path = "UIKit+AFNetworking/AFNetworkActivityIndicatorManager.m"; sourceTree = "<group>"; };
+		EB11CD05067DAEC2892329BD /* Pods-EditorDemoTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-EditorDemoTests.debug.xcconfig"; sourceTree = "<group>"; };
+		EB96F0A45B47C6C5D19988C5 /* WPEditorToolbarView.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = WPEditorToolbarView.h; sourceTree = "<group>"; };
+		ECABBDDEFD7029DCC1CF274C /* OpenSans-SemiboldItalic.ttf */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = file; name = "OpenSans-SemiboldItalic.ttf"; path = "WordPress-iOS-Shared/Assets/OpenSans-SemiboldItalic.ttf"; sourceTree = "<group>"; };
+		EE0C32445AB6CD2838D91647 /* WPTableViewSectionFooterView.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = WPTableViewSectionFooterView.h; path = "WordPress-iOS-Shared/Core/WPTableViewSectionFooterView.h"; sourceTree = "<group>"; };
+		EEFB446E2FD00B86FE17D354 /* Pods-EditorDemo.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-EditorDemo.release.xcconfig"; sourceTree = "<group>"; };
+		EF2B354FCE81E8EBA9DDA2B3 /* Pods-EditorDemo-AFNetworking.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-EditorDemo-AFNetworking.xcconfig"; sourceTree = "<group>"; };
+		F0F84B0A2337008BFEC8305B /* icon_format_italic@3x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = "icon_format_italic@3x.png"; sourceTree = "<group>"; };
+		F1C04F3F3D4AD90EC1CF60C6 /* DDMultiFormatter.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = DDMultiFormatter.m; path = Classes/Extensions/DDMultiFormatter.m; sourceTree = "<group>"; };
+		F2C07F7D3B78CFCEAC52945D /* Pods-EditorDemo-AFNetworking-Private.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-EditorDemo-AFNetworking-Private.xcconfig"; sourceTree = "<group>"; };
+		F332E993DF63EE57033387E2 /* icon_format_media@2x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = "icon_format_media@2x.png"; sourceTree = "<group>"; };
+		F5F7833A0169DF03AAF37725 /* Pods-EditorDemoTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-EditorDemoTests.release.xcconfig"; sourceTree = "<group>"; };
+		F601B5F2BBDB10B9C92E1F2B /* icon_format_more@2x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = "icon_format_more@2x.png"; sourceTree = "<group>"; };
+		F64D00770C289DCCC3ADD806 /* ZSStextcolor.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = ZSStextcolor.png; sourceTree = "<group>"; };
+		F6D4DB0B4FBE1F6A662937D5 /* UIActivityIndicatorView+AFNetworking.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIActivityIndicatorView+AFNetworking.h"; path = "UIKit+AFNetworking/UIActivityIndicatorView+AFNetworking.h"; sourceTree = "<group>"; };
+		F719137B3A33761B4EBE8024 /* icon_format_strikethrough.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = icon_format_strikethrough.png; sourceTree = "<group>"; };
+		F7705589E47D909A0E8CCF65 /* wpposter.svg */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xml; path = wpposter.svg; sourceTree = "<group>"; };
+		F79DE4F12605DE4BD7A9B387 /* WPImageSource.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = WPImageSource.m; path = "WordPress-iOS-Shared/Core/WPImageSource.m"; sourceTree = "<group>"; };
+		F80F6772DCA607F7CBC181C7 /* Pods-EditorDemo-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-EditorDemo-resources.sh"; sourceTree = "<group>"; };
+		F8856C375E1B9CD7D48506CA /* Pods-EditorDemo-WordPress-iOS-Shared-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-EditorDemo-WordPress-iOS-Shared-dummy.m"; sourceTree = "<group>"; };
+		F8917F269CE4458D3BED71A2 /* ZSSundo@2x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = "ZSSundo@2x.png"; sourceTree = "<group>"; };
+		F92539183359EB4FF19CD625 /* UIAlertView+AFNetworking.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "UIAlertView+AFNetworking.m"; path = "UIKit+AFNetworking/UIAlertView+AFNetworking.m"; sourceTree = "<group>"; };
+		F9AB73690ECF3D21F89D27F4 /* UIAlertView+Blocks.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "UIAlertView+Blocks.h"; sourceTree = "<group>"; };
+		F9B4EF0414A8CD0025050E0A /* ZSSbgcolor.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = ZSSbgcolor.png; sourceTree = "<group>"; };
+		FB6AA4BA7CEA049494551C3D /* WPNUXUtility.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = WPNUXUtility.h; path = "WordPress-iOS-Shared/Core/WPNUXUtility.h"; sourceTree = "<group>"; };
+		FC8742FD7D643EDCFFE1A2A0 /* WPEditorLoggingConfiguration.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = WPEditorLoggingConfiguration.h; sourceTree = "<group>"; };
+		FCBD9FF897F946CC0EAEAA26 /* WPLegacyEditorViewController.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = WPLegacyEditorViewController.m; sourceTree = "<group>"; };
+		FD982447098BDC0FF09F9121 /* UIColor+Helpers.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "UIColor+Helpers.h"; path = "WordPress-iOS-Shared/Core/UIColor+Helpers.h"; sourceTree = "<group>"; };
+		FE3F9F6081F04307C5F8F75C /* CYRTextStorage.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = CYRTextStorage.h; sourceTree = "<group>"; };
+		FF33C395DCFB5592ECDC6C21 /* Pods-EditorDemo-CocoaLumberjack-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-EditorDemo-CocoaLumberjack-prefix.pch"; sourceTree = "<group>"; };
+		FF915CAFDE4D469F90759FD9 /* Pods-EditorDemoTests-CocoaLumberjack-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "Pods-EditorDemoTests-CocoaLumberjack-dummy.m"; path = "../Pods-EditorDemoTests-CocoaLumberjack/Pods-EditorDemoTests-CocoaLumberjack-dummy.m"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		14D8C4491D76D05893E578A5 /* Frameworks */ = {
+		170DCF4628520134C7419635 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				054B1E3F683A9DDC12510EA4 /* Foundation.framework in Frameworks */,
+				6DD8D7CC3089C10D28AECDFE /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		27276544C942228E2772FD3C /* Frameworks */ = {
+		5907DAD2866EE2BD35DE5058 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				EB9AF8DB95DA0B7CFCC670A3 /* CoreGraphics.framework in Frameworks */,
-				98EE522FB09BA5B821A7A63F /* Foundation.framework in Frameworks */,
-				B7886A7E24A421E5E55EFB7F /* MobileCoreServices.framework in Frameworks */,
-				BDE8E5739C5A567ED4A0F7C2 /* Security.framework in Frameworks */,
-				E8796A2ECA9AC7D9D2712D19 /* SystemConfiguration.framework in Frameworks */,
+				19212F63A9E774760E50F180 /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		2CB37AB4936BDE4B19845492 /* Frameworks */ = {
+		5AB68B682B6BD3C4F124A31C /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				3F5C1D81D55B3A781CADC46A /* Foundation.framework in Frameworks */,
+				7EE576702B238DB4211AB2D4 /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		38DC750FF82AE104ABA33E40 /* Frameworks */ = {
+		6913164D3D22553CD7ED509C /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				1C9A0E335DF329424FE720C7 /* Foundation.framework in Frameworks */,
+				3AA484C0C473BE9F2475EA51 /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		92144277EB9C9A045A7F1604 /* Frameworks */ = {
+		B2D11EBA9A08EEE8D8945D7E /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				0584C5259E1E816E59A3D05B /* Foundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		BA08E6CA93D953DC70610315 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				0725DE584377196935DFD0BD /* CoreGraphics.framework in Frameworks */,
+				D99ED9DFF4D6CDE4BC89C16D /* Foundation.framework in Frameworks */,
+				E040F2B361B456A9D8D47F22 /* MobileCoreServices.framework in Frameworks */,
+				C4BD930116AB06713D193C1F /* Security.framework in Frameworks */,
+				D542E20CB0FCD6164F17FDE8 /* SystemConfiguration.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		C49A9F91366B9003F1D4A458 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				456DF8572B87B1ED58646325 /* Foundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D52D42973DB039044D001B4C /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				058A3A79B349A915456E5032 /* Foundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DE6B4E3D759756316FD2C1A9 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		A15019331BF95EEBB2769D8B /* Frameworks */ = {
+		E70DE130E4AFD15B79F03D15 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				32FC4BC30B50E98C7447B0B7 /* Foundation.framework in Frameworks */,
+				0CC40EE7CE8663BE425A3C8E /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		B09794C3E668034045BBC420 /* Frameworks */ = {
+		E94D99520F114470563B2341 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				477184D05437F19DA4166240 /* Foundation.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		B3D030975FC5C449CBEA58C7 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				0118DC3FEF939C33E10A5434 /* Foundation.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		B864EB6909A4CC585E6E2966 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				F8D76B8118E439C3ED90BCA4 /* Foundation.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		B9DEE4933931CD491103CD7E /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				B97844ED6D864BCA4601B8C1 /* Foundation.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		D754C5B832F2AB7859A721CA /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				B8F3BE4B3667C2B0827F9344 /* Foundation.framework in Frameworks */,
+				ADD93F61130631C439990F22 /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		034C13393CD81C4412D45781 /* UIAlertView+Blocks */ = {
+		007565CB4EBC02B80C6ABA38 /* Resources */ = {
 			isa = PBXGroup;
 			children = (
-				018979C89C385724745283B5 /* UIAlertView+Blocks.h */,
-				3BA661786D95821487D4AE8F /* UIAlertView+Blocks.m */,
-				6945EF0ECD21F54289300BC2 /* Support Files */,
+				44DC9BF94D0FCA6892703CC3 /* Merriweather-Bold.ttf */,
+				849E16B8E6FBAD38FBBB605A /* Merriweather-BoldItalic.otf */,
+				E008A051AE16697FBF99938F /* Merriweather-Italic.otf */,
+				5B62FE1DB620BA0F7EC28E47 /* Merriweather-Light.ttf */,
+				4C86F7989DFF3E0ACF0B5353 /* Merriweather-LightItalic.otf */,
+				A5B427F064254477FBBD5E6D /* Merriweather-Regular.ttf */,
+				35B5684797DBC61EB1EDE504 /* OpenSans-Bold.ttf */,
+				C55B74F70932078898621BEB /* OpenSans-BoldItalic.ttf */,
+				30859BF8628CBD0DE0A5AF66 /* OpenSans-Italic.ttf */,
+				184CDEC9AEEA4AB4456EE297 /* OpenSans-Light.ttf */,
+				22D44D1AE026AFC29A21973D /* OpenSans-LightItalic.ttf */,
+				B1A4B03D05F71C61BD430F79 /* OpenSans-Regular.ttf */,
+				7EBA66A1BD335B70B21AF8D3 /* OpenSans-Semibold.ttf */,
+				ECABBDDEFD7029DCC1CF274C /* OpenSans-SemiboldItalic.ttf */,
 			);
-			path = "UIAlertView+Blocks";
+			name = Resources;
 			sourceTree = "<group>";
 		};
-		0872BB9053EDF9654D42C496 /* Default */ = {
+		0827F415E259A7DCF2B4FCEA /* WordPressCom-Analytics-iOS */ = {
 			isa = PBXGroup;
 			children = (
-				F6EB761F023C2915B634E16C /* CocoaLumberjack.h */,
+				89178CA53DE5E6AADB6E2DC8 /* WPAnalytics.h */,
+				5B2680213E17A1E146706669 /* WPAnalytics.m */,
+				763AEC0A4EDA3DEBFC2060AE /* Support Files */,
 			);
-			name = Default;
+			path = "WordPressCom-Analytics-iOS";
 			sourceTree = "<group>";
 		};
-		244EFF438BAAF1C46B07A06D /* WordPress-iOS-Shared */ = {
+		0BBD3BA262DA2D6BC2D9C0E9 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				F7B60B3A45487A8D0FE93430 /* NSString+Util.h */,
-				8CA0CC8A3814CF370038663E /* NSString+Util.m */,
-				3B5573793DECA2290AFBAA22 /* NSString+XMLExtensions.h */,
-				A23DAF8B4FD9C9CA1D33FEBD /* NSString+XMLExtensions.m */,
-				EC8495EA7D6F0DE9DC90C99F /* UIColor+Helpers.h */,
-				14F28812D5D2F11A0E018098 /* UIColor+Helpers.m */,
-				112CC384C22A5E4734216238 /* UIImage+Util.h */,
-				C177B27AF8DF7D5DDF5266C0 /* UIImage+Util.m */,
-				E50FB26B160A58EF2B22DC7E /* UITableViewTextFieldCell.h */,
-				9E986D24AFB113B21A461F3C /* UITableViewTextFieldCell.m */,
-				091546E15BC3F0E725600780 /* WPAnimatedImageResponseSerializer.h */,
-				17A14C852C9344ACAE60A163 /* WPAnimatedImageResponseSerializer.m */,
-				AB0222DB5D4D25C5B5EA30BF /* WPDeviceIdentification.h */,
-				75EF4EE3B758B6379239E1E2 /* WPDeviceIdentification.m */,
-				22CAAD3B6A1A315A25DDAC72 /* WPFontManager.h */,
-				92029A24BD00438DF69F3430 /* WPFontManager.m */,
-				62FDA82F50D9AB1BF1110A0B /* WPImageSource.h */,
-				BC2035E92C1E87AA65F80397 /* WPImageSource.m */,
-				1DF3E84B7B3532517590657B /* WPNUXUtility.h */,
-				6D16E030A7855D156F8D6873 /* WPNUXUtility.m */,
-				F1A9AB7D49A0C6AA9AEE8636 /* WPNoResultsView.h */,
-				1DBF976142E1D7C7799DD0F9 /* WPNoResultsView.m */,
-				56E3A2813DD6D93629C0FD63 /* WPStyleGuide.h */,
-				0AE80F9D135E74992FBF0F68 /* WPStyleGuide.m */,
-				B76B72C0429B654F78ABED10 /* WPTableViewCell.h */,
-				09D1BCFC1F4E975478078E92 /* WPTableViewCell.m */,
-				FDD4B3EA92489A784DB3B3E7 /* WPTableViewSectionFooterView.h */,
-				1B42E8DEA5EED6E7D484E62D /* WPTableViewSectionFooterView.m */,
-				D6E546B2C69B6D23F6A3175A /* WPTableViewSectionHeaderView.h */,
-				2AF247072D334D8C21A3B339 /* WPTableViewSectionHeaderView.m */,
-				55CEA1D27A34219D2F1A93A1 /* Resources */,
-				EAD172B0C58083889931E4BE /* Support Files */,
+				7BBE9E4C1D09B1398C3EB085 /* WordPress-iOS-Shared.bundle */,
+				2EE706467EA5CF1BFAD412F6 /* libPods-EditorDemo.a */,
+				8C4B50D9E38CB0C5DC4C6E52 /* libPods-EditorDemo-AFNetworking.a */,
+				C74F3D313646F7D2310B5F81 /* libPods-EditorDemo-CocoaLumberjack.a */,
+				5F5C0A4D9CAF7343AC166722 /* libPods-EditorDemo-NSObject-SafeExpectations.a */,
+				56611B202B6287B13093772B /* libPods-EditorDemo-UIAlertView+Blocks.a */,
+				7F04CE6130A817BDD0CD1801 /* libPods-EditorDemo-WordPress-iOS-Editor.a */,
+				AB5CEF469BB8828385E8B670 /* libPods-EditorDemo-WordPress-iOS-Shared.a */,
+				617E743CCBD34CC14239ED5F /* libPods-EditorDemo-WordPressCom-Analytics-iOS.a */,
+				94424D69775A77CFB3BD44C9 /* libPods-EditorDemoTests.a */,
+				3473C21F8B5263449BD7A604 /* libPods-EditorDemoTests-CocoaLumberjack.a */,
 			);
-			path = "WordPress-iOS-Shared";
+			name = Products;
 			sourceTree = "<group>";
 		};
-		26BB225CB10ADB00EAD74FD2 /* AFNetworking */ = {
+		0DC653B5389BA3B57376BEA5 /* Classes */ = {
 			isa = PBXGroup;
 			children = (
-				D5213EE2040E6B3573D93D9A /* AFNetworking.h */,
-				767AC317502DA47AE0C2AA91 /* NSURLConnection */,
-				AEBBBD9E7D51A56950ED0A28 /* NSURLSession */,
-				CA783A7FFB461DEFA221B616 /* Reachability */,
-				F304D0AB18542C6FB8D19246 /* Security */,
-				98FBADECBA2EC73299CCD754 /* Serialization */,
-				9A80F466F652A3E5547F5E94 /* Support Files */,
-				EF3405B9130ECB3F6453BA51 /* UIKit */,
+				C8F378A41CF4CCD2565AA20A /* CYRLayoutManager.h */,
+				1AB7A659E7CEB4106CF7E4DD /* CYRLayoutManager.m */,
+				FE3F9F6081F04307C5F8F75C /* CYRTextStorage.h */,
+				E0B8D2BA2411BE41144FF737 /* CYRTextStorage.m */,
+				B0DA4757DEBA061F8BEA5C90 /* CYRTextView.h */,
+				C4D86EFAE2EDA6F2B3557225 /* CYRTextView.m */,
+				538275645AFBCEE7FF7065A1 /* CYRToken.h */,
+				242FC6638990FE497706BE53 /* CYRToken.m */,
+				74442FB3EEB4B3483B2DE99F /* HRBrightnessCursor.h */,
+				75E48F1669F5240C37D42CD0 /* HRBrightnessCursor.m */,
+				4C6F28CA3F79CD33878D4A2A /* HRCgUtil.h */,
+				5014F8280E10445967428D5E /* HRCgUtil.m */,
+				03681D95AF9171E060FCCA7E /* HRColorCursor.h */,
+				76BDC2FCBC2BA88FB97A16C5 /* HRColorCursor.m */,
+				C83A43068A5FFDDFCA024565 /* HRColorPickerMacros.h */,
+				A7D62E2AEE9F4BDDAF121FB7 /* HRColorPickerView.h */,
+				69E26CA56F380BD51A9A5780 /* HRColorPickerView.m */,
+				1838BF695A15C46138327B6A /* HRColorPickerViewController.h */,
+				749D6965D9B4AC4956B45D4A /* HRColorPickerViewController.m */,
+				E667E8C13719F24F6E718AD9 /* HRColorUtil.h */,
+				B163A43834E87052599E6D53 /* HRColorUtil.m */,
+				B15945148F4AEB9DBDB51856 /* UIWebView+GUIFixes.h */,
+				0F4C1C6D7959E19FE3017BEC /* UIWebView+GUIFixes.m */,
+				E8A4B42045977FD8F38D2E48 /* WPEditorField.h */,
+				6C1DD8384513A2FD9BB9C2AE /* WPEditorField.m */,
+				FC8742FD7D643EDCFFE1A2A0 /* WPEditorLoggingConfiguration.h */,
+				90FD1475E81FF37A85C5BF31 /* WPEditorLoggingConfiguration.m */,
+				70967CF7678EDC88A3D32E0F /* WPEditorToolbarButton.h */,
+				AA1A34EBC1C052DDD1904412 /* WPEditorToolbarButton.m */,
+				EB96F0A45B47C6C5D19988C5 /* WPEditorToolbarView.h */,
+				A5CAF1034DE3F578EB766D29 /* WPEditorToolbarView.m */,
+				23A06DEFC23188E688169C2D /* WPEditorView.h */,
+				420D65E0EAB5DFA8861D01FB /* WPEditorView.m */,
+				202F5E43C3E3A51610693AD5 /* WPEditorViewController.h */,
+				7A17FE572B152A4B1AFCC6EF /* WPEditorViewController.m */,
+				6B5871EF1DB454680B239044 /* WPImageMeta.h */,
+				C5B61413E187F9BC0C37CEE1 /* WPImageMeta.m */,
+				408293AB03EE4D0333F59F94 /* WPLegacyEditorViewController.h */,
+				FCBD9FF897F946CC0EAEAA26 /* WPLegacyEditorViewController.m */,
+				461E47229FF250FB9C85BDDF /* WPLegacyKeyboardToolbarBase.h */,
+				4136FEC8DF0711065CDF11DC /* WPLegacyKeyboardToolbarBase.m */,
+				A3667D4368AC7BD98AB11EBE /* WPLegacyKeyboardToolbarButtonItem.h */,
+				83D6D3668F3C091493AE9921 /* WPLegacyKeyboardToolbarButtonItem.m */,
+				A6D0FB35913872011A176B84 /* WPLegacyKeyboardToolbarDone.h */,
+				1F2E7064DF0BA8CF58089FB9 /* WPLegacyKeyboardToolbarDone.m */,
+				5003CDF4976CB62213B55E95 /* ZSSBarButtonItem.h */,
+				E7E9E00054084C2BD9AE08A6 /* ZSSBarButtonItem.m */,
+				7681897CF50837832FE2299B /* ZSSTextView.h */,
+				75C887F2FFC0C86B017A0ADB /* ZSSTextView.m */,
 			);
-			path = AFNetworking;
+			path = Classes;
 			sourceTree = "<group>";
 		};
-		2E63555956F325130352EF77 /* Core */ = {
+		118461425640EC37D676E0FD /* Support Files */ = {
 			isa = PBXGroup;
 			children = (
-				3DF5463DDA4D731C6A03FB50 /* DDASLLogCapture.h */,
-				54676799AFC754686D4A4FEA /* DDASLLogCapture.m */,
-				98DF48F13D4655D8543E518B /* DDASLLogger.h */,
-				89235079FAB59221611D63CD /* DDASLLogger.m */,
-				EF4686D53017634E6BEBA1CF /* DDAbstractDatabaseLogger.h */,
-				94D8943D1DD7246DC92AD2DB /* DDAbstractDatabaseLogger.m */,
-				C80A806DD95999A06EF1959D /* DDAssertMacros.h */,
-				310C01090D1A63E9DA5240B6 /* DDFileLogger.h */,
-				DF23B2473711D04DCCCF8D23 /* DDFileLogger.m */,
-				55D9883308BCDF32781C842C /* DDLegacyMacros.h */,
-				E32BBF04BBF9BDAF1DA8BD9D /* DDLog.h */,
-				865CB62E80D7764017A36D83 /* DDLog.m */,
-				74357F1BFC1EC208F76D99A6 /* DDLog+LOGV.h */,
-				8D7EC5A03EE293E016E05897 /* DDLogMacros.h */,
-				83B76071665DF829399714BF /* DDTTYLogger.h */,
-				1350BA0F996FFA831EED6BEB /* DDTTYLogger.m */,
-			);
-			name = Core;
-			sourceTree = "<group>";
-		};
-		359C9AE319C9743571C81A5A /* Frameworks */ = {
-			isa = PBXGroup;
-			children = (
-				5FF96A7E64177DE2FE8ADDC9 /* iOS */,
-			);
-			name = Frameworks;
-			sourceTree = "<group>";
-		};
-		426A8B32F731C9424DD25E82 /* Support Files */ = {
-			isa = PBXGroup;
-			children = (
-				EB33533D90A0124759E562AA /* Pods-EditorDemo-CocoaLumberjack.xcconfig */,
-				95625436A073EB8182AEF56A /* Pods-EditorDemo-CocoaLumberjack-Private.xcconfig */,
-				9D3595BFBDFDEB62A1D59A6D /* Pods-EditorDemo-CocoaLumberjack-dummy.m */,
-				4F4BA5D091BECE219AC5EF57 /* Pods-EditorDemo-CocoaLumberjack-prefix.pch */,
-				13B9F5A3DB671D9E4E786139 /* Pods-EditorDemoTests-CocoaLumberjack.xcconfig */,
-				66CB0A484B346F4A872A79AE /* Pods-EditorDemoTests-CocoaLumberjack-Private.xcconfig */,
-				5A8549A279C4AFD919B26398 /* Pods-EditorDemoTests-CocoaLumberjack-dummy.m */,
-				2446A8148FA3150F669D6A7B /* Pods-EditorDemoTests-CocoaLumberjack-prefix.pch */,
+				00AEED7B8808F9F44CC44207 /* Pods-EditorDemo-CocoaLumberjack.xcconfig */,
+				A2F7B749D27EDAD85F31094B /* Pods-EditorDemo-CocoaLumberjack-Private.xcconfig */,
+				D433D2E8A688F8A9CAFFB415 /* Pods-EditorDemo-CocoaLumberjack-dummy.m */,
+				FF33C395DCFB5592ECDC6C21 /* Pods-EditorDemo-CocoaLumberjack-prefix.pch */,
+				E0CB942B52E318E6F4317D9E /* Pods-EditorDemoTests-CocoaLumberjack.xcconfig */,
+				3FDA9FF74C52D9ECF0E91763 /* Pods-EditorDemoTests-CocoaLumberjack-Private.xcconfig */,
+				FF915CAFDE4D469F90759FD9 /* Pods-EditorDemoTests-CocoaLumberjack-dummy.m */,
+				289EF6335C5A9E59F891F170 /* Pods-EditorDemoTests-CocoaLumberjack-prefix.pch */,
 			);
 			name = "Support Files";
 			path = "../Target Support Files/Pods-EditorDemo-CocoaLumberjack";
 			sourceTree = "<group>";
 		};
-		4AD30E23BC40842A477A945A = {
+		19408AB415D01C66EA4EBA6F /* CocoaLumberjack */ = {
 			isa = PBXGroup;
 			children = (
-				258129337B6C3AC311D01813 /* Podfile */,
-				CDB4DD9783A0026E3924809E /* Development Pods */,
-				359C9AE319C9743571C81A5A /* Frameworks */,
-				909E33CA5937C02A20D81D03 /* Pods */,
-				BCFBD51D6D8D3153A10B4B79 /* Products */,
-				BC671178481370A837CF6436 /* Targets Support Files */,
+				80E13B7E8CC431F439E71519 /* Core */,
+				927EF1958F1A3D4963B1828B /* Default */,
+				E9C808C73F49A6E56A95B862 /* Extensions */,
+				118461425640EC37D676E0FD /* Support Files */,
 			);
+			path = CocoaLumberjack;
 			sourceTree = "<group>";
 		};
-		5402FAB1C513D1CC20C63E02 /* NSObject-SafeExpectations */ = {
+		1A2E55BFA6F9EBCF85EEE1C2 /* WordPress-iOS-Shared */ = {
 			isa = PBXGroup;
 			children = (
-				176C9DE7D881606395EE8288 /* NSDictionary+SafeExpectations.h */,
-				BBFF0636DD0ACBEF7709787A /* NSDictionary+SafeExpectations.m */,
-				B563C04BA3C2A510A9F8495F /* NSObject+SafeExpectations.h */,
-				A6147B935AECE1479204472C /* Support Files */,
+				42A02C404A0FB82B3E225C21 /* NSString+Util.h */,
+				5FC5BB613559A5EF42318132 /* NSString+Util.m */,
+				E523C7CAD67485E52A339467 /* NSString+XMLExtensions.h */,
+				9B32D85834184C4D9047C37D /* NSString+XMLExtensions.m */,
+				FD982447098BDC0FF09F9121 /* UIColor+Helpers.h */,
+				01B925E4371AA877422D1B0E /* UIColor+Helpers.m */,
+				B97B1EE3D83CF6F0BBAD6C5B /* UIImage+Util.h */,
+				36944359AB06987437512C83 /* UIImage+Util.m */,
+				7A4CAA54E3B816D1E4362729 /* UITableViewTextFieldCell.h */,
+				D5B41411BF9D5EF07E5B975D /* UITableViewTextFieldCell.m */,
+				E5F5019259C6F329D71795FC /* WPAnimatedImageResponseSerializer.h */,
+				E27B8D0B439915F8D923D746 /* WPAnimatedImageResponseSerializer.m */,
+				C8484604FD3033710AB6DE62 /* WPDeviceIdentification.h */,
+				A04E1DC754C74A9AFAF22576 /* WPDeviceIdentification.m */,
+				DF0EE4D20EF36C3B74332D25 /* WPFontManager.h */,
+				7CB2348B9191FFBAF446C505 /* WPFontManager.m */,
+				43E12506949E3528076FD742 /* WPImageSource.h */,
+				F79DE4F12605DE4BD7A9B387 /* WPImageSource.m */,
+				FB6AA4BA7CEA049494551C3D /* WPNUXUtility.h */,
+				34709FADBBDA7A7B1005CD94 /* WPNUXUtility.m */,
+				C986ECA9682A194B494E39FD /* WPNoResultsView.h */,
+				7334EA17018B09751A95A371 /* WPNoResultsView.m */,
+				2FAC1F4B3EA04E156178F03A /* WPStyleGuide.h */,
+				62DB79E852F20BF71B5EA023 /* WPStyleGuide.m */,
+				8D2907D3E03FDD35B890C6EB /* WPTableViewCell.h */,
+				39A6D2B1D31F514BE1BCB543 /* WPTableViewCell.m */,
+				EE0C32445AB6CD2838D91647 /* WPTableViewSectionFooterView.h */,
+				92734290DB026F15AF179C9A /* WPTableViewSectionFooterView.m */,
+				6550526B8CFC8CDCE4485C85 /* WPTableViewSectionHeaderView.h */,
+				3ED80500DFCEC27F4AE8C221 /* WPTableViewSectionHeaderView.m */,
+				007565CB4EBC02B80C6ABA38 /* Resources */,
+				B5FBC27E49C23D20BED6497E /* Support Files */,
 			);
-			path = "NSObject-SafeExpectations";
+			path = "WordPress-iOS-Shared";
 			sourceTree = "<group>";
 		};
-		55CEA1D27A34219D2F1A93A1 /* Resources */ = {
+		35A8796224915F38E04FA264 /* Development Pods */ = {
 			isa = PBXGroup;
 			children = (
-				056879325A78CF12075A1053 /* Merriweather-Bold.ttf */,
-				060F276754F0350A2FA05117 /* Merriweather-BoldItalic.otf */,
-				327E6EC8D455841FD0FBEFE8 /* Merriweather-Italic.otf */,
-				A261037F1CFEE61E5ABF30E8 /* Merriweather-Light.ttf */,
-				BF05E9C99DBD7D58BD72C47B /* Merriweather-LightItalic.otf */,
-				1D4D5A88C0F26EFC90814CB1 /* Merriweather-Regular.ttf */,
-				68863BCB654EC023916826BD /* OpenSans-Bold.ttf */,
-				A26F4D31A1E5025CB011DAB6 /* OpenSans-BoldItalic.ttf */,
-				26E373A57F6558BBFBDC1667 /* OpenSans-Italic.ttf */,
-				284390BBC552E83AAEA885A3 /* OpenSans-Light.ttf */,
-				C2A651F702836255E1BF6923 /* OpenSans-LightItalic.ttf */,
-				6893DCC647C2B6A10590134B /* OpenSans-Regular.ttf */,
-				3CDF9ED71C9C92EC63F6BFBE /* OpenSans-Semibold.ttf */,
-				4C1A99A1ED8BB763DDCF154F /* OpenSans-SemiboldItalic.ttf */,
+				506B30CF4CFA05D5389825D4 /* WordPress-iOS-Editor */,
+			);
+			name = "Development Pods";
+			sourceTree = "<group>";
+		};
+		3F056102C6DCD741DFA0636C /* Resources */ = {
+			isa = PBXGroup;
+			children = (
+				ECE72B6DBBE8F00DD6BCDD37 /* Assets */,
 			);
 			name = Resources;
 			sourceTree = "<group>";
 		};
-		59B5C1DEBC58FF11FBFA8073 /* Classes */ = {
+		4AA66900CC2026B2B9E4D8BA = {
 			isa = PBXGroup;
 			children = (
-				A82B16455309483C9C249630 /* CYRLayoutManager.h */,
-				9AFDF5C977A47006BC807E8F /* CYRLayoutManager.m */,
-				E7A1DB0FDF5244C4E92C208D /* CYRTextStorage.h */,
-				AB1B4D0769C3B24AF938ECE4 /* CYRTextStorage.m */,
-				34A701B8110E840B28A9D42B /* CYRTextView.h */,
-				280FCC792BA9A1849E28B5E3 /* CYRTextView.m */,
-				BC5F8CC72F610AF6F2377B5E /* CYRToken.h */,
-				D8B21B104C492B33C5198F0C /* CYRToken.m */,
-				A83EBE9737B76BD1DB10EB25 /* HRBrightnessCursor.h */,
-				98EE8483A445597F06C792DE /* HRBrightnessCursor.m */,
-				1D4D93A62C39721D8A512F8F /* HRCgUtil.h */,
-				86B2B8EBE5E7BD54D211245F /* HRCgUtil.m */,
-				8BEB2D35D07C89F0DFD67FCE /* HRColorCursor.h */,
-				AB056485C7A7A2F6AE95F541 /* HRColorCursor.m */,
-				EFC7E7D7222CB606DE916907 /* HRColorPickerMacros.h */,
-				317C00A0F2D55B4BFD06B22E /* HRColorPickerView.h */,
-				924B5F6047D3307240D1F128 /* HRColorPickerView.m */,
-				7170B9F00A185ACE9C143787 /* HRColorPickerViewController.h */,
-				FB0E6E4AEFB946AD32EF2296 /* HRColorPickerViewController.m */,
-				8A38F0FFC96FDCCDD12B1AFA /* HRColorUtil.h */,
-				DCAD6D44CF75602B883DB7B2 /* HRColorUtil.m */,
-				F79DFC09DF5D304117C8C985 /* UIWebView+GUIFixes.h */,
-				6DB2247E9DE38BAB3598AA4F /* UIWebView+GUIFixes.m */,
-				E7FE277C295E137B551C1D28 /* WPEditorField.h */,
-				974D2A9D4653F8E38D2F0C40 /* WPEditorField.m */,
-				768BD1B9A7536355AE0F9F15 /* WPEditorLoggingConfiguration.h */,
-				79A01D6C15846ECFFE1686F3 /* WPEditorLoggingConfiguration.m */,
-				3ACCAC699D9B945C6C36B45F /* WPEditorToolbarButton.h */,
-				AD955A9EED4C718A51BAF067 /* WPEditorToolbarButton.m */,
-				9D77FE1E5CA966152EEB3DE9 /* WPEditorToolbarView.h */,
-				55DF2E3BACB825D7471A8FEC /* WPEditorToolbarView.m */,
-				E07BCBF46CA37C59069257EF /* WPEditorView.h */,
-				D8F18A6D0A8419F77D340D21 /* WPEditorView.m */,
-				EC99DF31A210C785E8C03009 /* WPEditorViewController.h */,
-				88FA75E4F70D037B1EFAAF75 /* WPEditorViewController.m */,
-				70DBC5EA925BD6CF3676657A /* WPImageMeta.h */,
-				BD1E570EF8189D86464C0E2C /* WPImageMeta.m */,
-				C403C7B8F58A796C79509BFB /* WPLegacyEditorViewController.h */,
-				80D829BCA25C76946462169A /* WPLegacyEditorViewController.m */,
-				0FD2B36D886DFC8099841A0B /* WPLegacyKeyboardToolbarBase.h */,
-				018FA367567DFEC4AD1F893F /* WPLegacyKeyboardToolbarBase.m */,
-				BFF08FB8ED207559997CDFB2 /* WPLegacyKeyboardToolbarButtonItem.h */,
-				BCE044252C4D68BE0AF67ED8 /* WPLegacyKeyboardToolbarButtonItem.m */,
-				B46B33D534E8A4F34D7096F7 /* WPLegacyKeyboardToolbarDone.h */,
-				BED91EE72D776DEC97ED65AC /* WPLegacyKeyboardToolbarDone.m */,
-				C569177FBD9DC3B1C3D9A082 /* ZSSBarButtonItem.h */,
-				B1D6D1525F0819EBB8B9A02D /* ZSSBarButtonItem.m */,
-				47CF243D1E5DAB7CF03588E9 /* ZSSTextView.h */,
-				BBFFAAEA0B13ACEC5DCD402D /* ZSSTextView.m */,
+				3854677C9837813EB95CF05B /* Podfile */,
+				35A8796224915F38E04FA264 /* Development Pods */,
+				5934D96AA03DFDCE010DCD10 /* Frameworks */,
+				4F900B210DA4EA301611A98F /* Pods */,
+				0BBD3BA262DA2D6BC2D9C0E9 /* Products */,
+				8AB615FB69D625810A69F8C3 /* Targets Support Files */,
 			);
-			path = Classes;
 			sourceTree = "<group>";
 		};
-		5BB5CE2DF61BDC23AB1C7151 /* WordPressCom-Analytics-iOS */ = {
+		4F900B210DA4EA301611A98F /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				C6B28B188BC62FD0DDF829FC /* WPAnalytics.h */,
-				F9BD038AD678226BAB2F4E6F /* WPAnalytics.m */,
-				CC46C0679E035EE3B53AC0D5 /* Support Files */,
-			);
-			path = "WordPressCom-Analytics-iOS";
-			sourceTree = "<group>";
-		};
-		5FF96A7E64177DE2FE8ADDC9 /* iOS */ = {
-			isa = PBXGroup;
-			children = (
-				E1851933ADEEDE4F6D7433FC /* CoreGraphics.framework */,
-				3FC1EFEC6EB6188975226AC3 /* Foundation.framework */,
-				5A5291133F8F6D24122120CE /* MobileCoreServices.framework */,
-				EBC991C6DFE83D4D4C3784D2 /* Security.framework */,
-				8931B68A09E383CD904DD45B /* SystemConfiguration.framework */,
-			);
-			name = iOS;
-			sourceTree = "<group>";
-		};
-		6945EF0ECD21F54289300BC2 /* Support Files */ = {
-			isa = PBXGroup;
-			children = (
-				6B52283D3232357AE696A170 /* Pods-EditorDemo-UIAlertView+Blocks.xcconfig */,
-				4405DA15440A4795151956A8 /* Pods-EditorDemo-UIAlertView+Blocks-Private.xcconfig */,
-				588DC83FD71E5DC28532E420 /* Pods-EditorDemo-UIAlertView+Blocks-dummy.m */,
-				6079A708C4A86F4C245E9F4F /* Pods-EditorDemo-UIAlertView+Blocks-prefix.pch */,
-			);
-			name = "Support Files";
-			path = "../Target Support Files/Pods-EditorDemo-UIAlertView+Blocks";
-			sourceTree = "<group>";
-		};
-		7276D8EF5A1427DA33D3287E /* Assets */ = {
-			isa = PBXGroup;
-			children = (
-				3FC1398D73E29D508B0A6EF7 /* WPHybridCallbacker.js */,
-				95B3FB54BCF2940567C3B742 /* WPHybridLogger.js */,
-				ABA387D73D80CA20A00660D6 /* ZSSRichTextEditor.js */,
-				04657334CF1393C9DA45499B /* ZSSbgcolor.png */,
-				45A33659A19AEADBA1C4E30E /* ZSSbgcolor@2x.png */,
-				0D0C7128CE5F7BD365035E58 /* ZSScenterjustify.png */,
-				15C3EB7321BB804FBCCC2B5B /* ZSScenterjustify@2x.png */,
-				63CE022F0C388C12A4764049 /* ZSSclearstyle.png */,
-				EAD51AE82173321DB6E8561F /* ZSSclearstyle@2x.png */,
-				F1C19E889B85B3DB19953FD0 /* ZSSforcejustify.png */,
-				F1A97083BD0FC62B75E9E95C /* ZSSforcejustify@2x.png */,
-				E80814E3E0FB2924CA17448D /* ZSSh1.png */,
-				4F1F77A475B60B38DC24BA0D /* ZSSh1@2x.png */,
-				85D185437C585F3172CDA947 /* ZSSh2.png */,
-				A54E2D46D6A0A3F6C1B62CF0 /* ZSSh2@2x.png */,
-				98A08728E71AC0662A9D1B85 /* ZSSh3.png */,
-				32D8AB3CB6135FD5386CB9AE /* ZSSh3@2x.png */,
-				E28E7089D526CDD36B58F701 /* ZSSh4.png */,
-				3AF37D46D87DE32A97B5232F /* ZSSh4@2x.png */,
-				03D7B2AC28815C9E1902F30C /* ZSSh5.png */,
-				A4620A669C2CBFCE0D47740A /* ZSSh5@2x.png */,
-				081D050556EF0814FE87552A /* ZSSh6.png */,
-				0840F86DFF61C244FAD606BA /* ZSSh6@2x.png */,
-				EC16E24A8EF5C39FA394C9AB /* ZSShorizontalrule.png */,
-				7F115578DD3EB1A11998881C /* ZSShorizontalrule@2x.png */,
-				CF333F81303BC03D65260EEE /* ZSSindent.png */,
-				E7E1CD7B14E2AA11BFA963F9 /* ZSSindent@2x.png */,
-				A6312DEE7C6B844FAC135D92 /* ZSSleftjustify.png */,
-				6083D30E6BF8EE9DDBB17DAB /* ZSSleftjustify@2x.png */,
-				8544E0C206CFCF4B12DF00FA /* ZSSoutdent.png */,
-				8D9774541DD39B37D7C9E281 /* ZSSoutdent@2x.png */,
-				9E66B9064D6118FA70A78B26 /* ZSSquicklink.png */,
-				24219DFBC8B4BA641480C086 /* ZSSquicklink@2x.png */,
-				ACF6EAEB12FC49237A334321 /* ZSSredo.png */,
-				F5DFFC76E7319AEF6B1E3BC9 /* ZSSredo@2x.png */,
-				98BC06F7B5A47776BD69A7BF /* ZSSrightjustify.png */,
-				C2DFA4D92395995F6A5C81B0 /* ZSSrightjustify@2x.png */,
-				EC0D1CB18E1778F3B303AFEC /* ZSSsubscript.png */,
-				A95615B899E0D9F831A4EFC9 /* ZSSsubscript@2x.png */,
-				F2FB0FD195C1EE60554B3A05 /* ZSSsuperscript.png */,
-				29AC6869AD6DAC9D9CAC15AF /* ZSSsuperscript@2x.png */,
-				49DDA0785FC0D8EC2BFED5EE /* ZSStextcolor.png */,
-				A95002292EBA0A8E1A8D96C5 /* ZSStextcolor@2x.png */,
-				8966441CAECECED37C5A669F /* ZSSundo.png */,
-				E9864BD97C3640399FB37841 /* ZSSundo@2x.png */,
-				F166847A9F567DFFFEF0018C /* editor.css */,
-				99CCFD2E23B202A3D27BA362 /* editor.html */,
-				D5AADFE47F9D90E4AFDA2477 /* icon-posts-editor-inspector.png */,
-				2ADA3E08D958D207EAE97E57 /* icon-posts-editor-inspector@2x.png */,
-				9D753DED78C2802CE68C3A41 /* icon-posts-editor-inspector@3x.png */,
-				92CFD91B9786B47D3D41F257 /* icon-posts-editor-preview.png */,
-				934EAFA1098F1F101E8D964F /* icon-posts-editor-preview@2x.png */,
-				73A06E71ACA570065D2E12FB /* icon-posts-editor-preview@3x.png */,
-				89232286CA4A51F955BA4485 /* icon_format_bold.png */,
-				1EA7E5C8BFE068046ABEDF8B /* icon_format_bold@2x.png */,
-				FC3B0027056C09810D6BE3F6 /* icon_format_bold@3x.png */,
-				3D8617C47E04FF8DDCA9AC70 /* icon_format_html.png */,
-				FF90D05A0C2E91FB332DA879 /* icon_format_html@2x.png */,
-				295202BE94C845BA62D71F35 /* icon_format_html@3x.png */,
-				0A7931B903B64940FDB91BCA /* icon_format_italic.png */,
-				CE66C4E4B2D48353ED45A4F9 /* icon_format_italic@2x.png */,
-				33A35730DA4CEBC0A9093099 /* icon_format_italic@3x.png */,
-				9B776362EEBDA487D94530EF /* icon_format_keyboard.png */,
-				E5917ED7054745EA2D4ED57C /* icon_format_keyboard@2x.png */,
-				9518F173377EFDE19D2D3CB6 /* icon_format_link.png */,
-				0111805967E885663F108E64 /* icon_format_link@2x.png */,
-				3B1A061BB4FE2A39D9878512 /* icon_format_link@3x.png */,
-				D219F8203537E059C077C940 /* icon_format_media.png */,
-				05C8E2635437A1E8EBB28608 /* icon_format_media@2x.png */,
-				FA98D8A5A16AE9A1DB0FE6B8 /* icon_format_media@3x.png */,
-				809B94A47BD95CEFD6046AF3 /* icon_format_more.png */,
-				29A69F5003A385EC9CE4B43E /* icon_format_more@2x.png */,
-				465DB5D3F074B688102F64FC /* icon_format_more@3x.png */,
-				9BDE7351115956FDB2791E85 /* icon_format_ol.png */,
-				6982929B5675E5E426B55CAD /* icon_format_ol@2x.png */,
-				15C935CB95046392FA40871B /* icon_format_ol@3x.png */,
-				90B5A89B7D038A784E82E264 /* icon_format_quote.png */,
-				FFC30D7354170D919C616AE4 /* icon_format_quote@2x.png */,
-				41CF213A50AFA329F1E34BE4 /* icon_format_quote@3x.png */,
-				F83111084A8B84059A5EC7AC /* icon_format_strikethrough.png */,
-				F410F168BE4F71C9887D9930 /* icon_format_strikethrough@2x.png */,
-				D3C8E408F68FC445587C5424 /* icon_format_strikethrough@3x.png */,
-				E1C99FFBBFB8B9404F1576C1 /* icon_format_ul.png */,
-				AFF499A9B99688E9DF426A19 /* icon_format_ul@2x.png */,
-				5EBFEFC4FE2E8C391CADB7E2 /* icon_format_ul@3x.png */,
-				8D0C2D1CC4780CAC805D7061 /* icon_format_underline.png */,
-				C38F10D5752B2DF9D6BD9D6A /* icon_format_underline@2x.png */,
-				2DEADA5A140D78363802CF2D /* icon_format_unlink.png */,
-				01D2A5EF4B44A19D2FB56234 /* icon_format_unlink@2x.png */,
-				3B1C3F20480ED33CD9AAD28F /* icon_options.png */,
-				FCC00753D323882477103756 /* icon_options@2x.png */,
-				5CAB8FFF0FAB266A65259BCE /* icon_preview.png */,
-				3C174C35F65ABD415D6A6912 /* icon_preview@2x.png */,
-				3374B7EF94C885A05367678A /* jquery.js */,
-				6CF49B02B746703CC492A022 /* jquery.mobile-events.min.js */,
-				5095C5D647072E0857D03F13 /* js-beautifier.js */,
-				4DEC78BFB5E2A6FAB2E62A8D /* rangy-classapplier.js */,
-				B1D00CD591028EF5127CD697 /* rangy-core.js */,
-				F2EE065202518018D189961F /* rangy-highlighter.js */,
-				87243AD8538521AD2434EC27 /* rangy-selectionsaverestore.js */,
-				DDF2FE148226BF7142422149 /* rangy-serializer.js */,
-				5FF4850648720959CE971516 /* rangy-textrange.js */,
-				DF0F502A0B28ED74BF7672A7 /* shortcode.js */,
-				E55877D05E8A4C6E80EC12CF /* underscore-min.js */,
-				C792E809F612994119012AF7 /* wpload.js */,
-				50BDDF1CB570638BB655698E /* wpposter.svg */,
-				D70B21F06CD25FEAF9117297 /* wpsave.js */,
-			);
-			path = Assets;
-			sourceTree = "<group>";
-		};
-		767AC317502DA47AE0C2AA91 /* NSURLConnection */ = {
-			isa = PBXGroup;
-			children = (
-				5C7240FA870002C3B38EB209 /* AFHTTPRequestOperation.h */,
-				6C616AE8E697E93A6E37DFF3 /* AFHTTPRequestOperation.m */,
-				4B0E4C244D73BA1DBC57A3ED /* AFHTTPRequestOperationManager.h */,
-				F6EEAF6E918D64B1B7AF9C33 /* AFHTTPRequestOperationManager.m */,
-				34ED3705F34F9E0B11228A4D /* AFURLConnectionOperation.h */,
-				B752A1B22EEBA84AAB04BC43 /* AFURLConnectionOperation.m */,
-			);
-			name = NSURLConnection;
-			sourceTree = "<group>";
-		};
-		77F55B60D5EA1ADEB08C480E /* Support Files */ = {
-			isa = PBXGroup;
-			children = (
-				8B606A313211700D3B8D617A /* Pods-EditorDemo-WordPress-iOS-Editor.xcconfig */,
-				1ACB5D3CD0353F368F0C28A2 /* Pods-EditorDemo-WordPress-iOS-Editor-Private.xcconfig */,
-				AD705BBE73395931249E6A99 /* Pods-EditorDemo-WordPress-iOS-Editor-dummy.m */,
-				699BDF7BAED524F26D0C67D3 /* Pods-EditorDemo-WordPress-iOS-Editor-prefix.pch */,
-			);
-			name = "Support Files";
-			path = "Example/Pods/Target Support Files/Pods-EditorDemo-WordPress-iOS-Editor";
-			sourceTree = "<group>";
-		};
-		9024A8A83FA32FFF97489FD4 /* Pods-EditorDemo */ = {
-			isa = PBXGroup;
-			children = (
-				A98ED62295FA964CAEA8F433 /* Pods-EditorDemo-acknowledgements.markdown */,
-				2C70C2404F595B1F9EE8479B /* Pods-EditorDemo-acknowledgements.plist */,
-				AACF3AC0715A74F944856827 /* Pods-EditorDemo-dummy.m */,
-				26DB64B02A6FE7131DF630E1 /* Pods-EditorDemo-environment.h */,
-				7F2B7736B3A9D2D34A7E3E43 /* Pods-EditorDemo-resources.sh */,
-				7291752A749BD1FB9C8FD07B /* Pods-EditorDemo.debug.xcconfig */,
-				6F77D6834FCEB81B689C42BA /* Pods-EditorDemo.release.xcconfig */,
-			);
-			name = "Pods-EditorDemo";
-			path = "Target Support Files/Pods-EditorDemo";
-			sourceTree = "<group>";
-		};
-		909E33CA5937C02A20D81D03 /* Pods */ = {
-			isa = PBXGroup;
-			children = (
-				26BB225CB10ADB00EAD74FD2 /* AFNetworking */,
-				FCA490EA19E24FF762ECA95A /* CocoaLumberjack */,
-				5402FAB1C513D1CC20C63E02 /* NSObject-SafeExpectations */,
-				034C13393CD81C4412D45781 /* UIAlertView+Blocks */,
-				244EFF438BAAF1C46B07A06D /* WordPress-iOS-Shared */,
-				5BB5CE2DF61BDC23AB1C7151 /* WordPressCom-Analytics-iOS */,
+				A7325CD94957F905D946761D /* AFNetworking */,
+				19408AB415D01C66EA4EBA6F /* CocoaLumberjack */,
+				BF1A0A484ACB01FF16548101 /* NSObject-SafeExpectations */,
+				B0A5F2EFD0927CD504ADCE5E /* UIAlertView+Blocks */,
+				1A2E55BFA6F9EBCF85EEE1C2 /* WordPress-iOS-Shared */,
+				0827F415E259A7DCF2B4FCEA /* WordPressCom-Analytics-iOS */,
 			);
 			name = Pods;
 			sourceTree = "<group>";
 		};
-		98FBADECBA2EC73299CCD754 /* Serialization */ = {
+		506B30CF4CFA05D5389825D4 /* WordPress-iOS-Editor */ = {
 			isa = PBXGroup;
 			children = (
-				A48F9E3F5784859E655DB860 /* AFURLRequestSerialization.h */,
-				37AEC98F2495EC75AFBE14FC /* AFURLRequestSerialization.m */,
-				92FD2D1BB51543C99FB78845 /* AFURLResponseSerialization.h */,
-				F399A5BAACE5836A5E67EF4C /* AFURLResponseSerialization.m */,
-			);
-			name = Serialization;
-			sourceTree = "<group>";
-		};
-		9A80F466F652A3E5547F5E94 /* Support Files */ = {
-			isa = PBXGroup;
-			children = (
-				CB265E7E9BFBE7B8AFF25B49 /* Pods-EditorDemo-AFNetworking.xcconfig */,
-				C74D92E6172B18645410B660 /* Pods-EditorDemo-AFNetworking-Private.xcconfig */,
-				59BCCAA21F5127D63C97A477 /* Pods-EditorDemo-AFNetworking-dummy.m */,
-				2F19287E9473481526024216 /* Pods-EditorDemo-AFNetworking-prefix.pch */,
-			);
-			name = "Support Files";
-			path = "../Target Support Files/Pods-EditorDemo-AFNetworking";
-			sourceTree = "<group>";
-		};
-		A59D65AE3D1055424F12B301 /* Extensions */ = {
-			isa = PBXGroup;
-			children = (
-				5D4410C08BCC867F603078B4 /* DDContextFilterLogFormatter.h */,
-				0DB2B67BABFAF4ED3D2ECB51 /* DDContextFilterLogFormatter.m */,
-				045EDAFF2CA6C9E03F1A9EFE /* DDDispatchQueueLogFormatter.h */,
-				BA17E35CEDDB3D58BD6B6A8D /* DDDispatchQueueLogFormatter.m */,
-				7C3132720A59BC1DD7C4FCDE /* DDMultiFormatter.h */,
-				F8B92DA817029F2EA817CCD9 /* DDMultiFormatter.m */,
-			);
-			name = Extensions;
-			sourceTree = "<group>";
-		};
-		A6147B935AECE1479204472C /* Support Files */ = {
-			isa = PBXGroup;
-			children = (
-				E8DEAB12964765566D166BD7 /* Pods-EditorDemo-NSObject-SafeExpectations.xcconfig */,
-				2BB0FEADE5DDFD462933EC4D /* Pods-EditorDemo-NSObject-SafeExpectations-Private.xcconfig */,
-				1232CFE2F61607CF8870E363 /* Pods-EditorDemo-NSObject-SafeExpectations-dummy.m */,
-				51DCE8D262D072511132F17B /* Pods-EditorDemo-NSObject-SafeExpectations-prefix.pch */,
-			);
-			name = "Support Files";
-			path = "../Target Support Files/Pods-EditorDemo-NSObject-SafeExpectations";
-			sourceTree = "<group>";
-		};
-		ACCC039B763AEF1E47543E5E /* Pods-EditorDemoTests */ = {
-			isa = PBXGroup;
-			children = (
-				D890A4D0818F60CA97317E36 /* Pods-EditorDemoTests-acknowledgements.markdown */,
-				0AD31CA003EF27F7E0FF2846 /* Pods-EditorDemoTests-acknowledgements.plist */,
-				59050B4B96496DFD8DD03035 /* Pods-EditorDemoTests-dummy.m */,
-				5D7B8551C93EAA0D264D2B5F /* Pods-EditorDemoTests-environment.h */,
-				BD83FC20EC006449066C6FA1 /* Pods-EditorDemoTests-resources.sh */,
-				5F85D8AA92A66EF2E1DDA8E9 /* Pods-EditorDemoTests.debug.xcconfig */,
-				6A5A0E79F9A6A2E44FD39CED /* Pods-EditorDemoTests.release.xcconfig */,
-			);
-			name = "Pods-EditorDemoTests";
-			path = "Target Support Files/Pods-EditorDemoTests";
-			sourceTree = "<group>";
-		};
-		AEBBBD9E7D51A56950ED0A28 /* NSURLSession */ = {
-			isa = PBXGroup;
-			children = (
-				F957BAE1810901BBCD142A36 /* AFHTTPSessionManager.h */,
-				943522988A655FD84657E486 /* AFHTTPSessionManager.m */,
-				87EBE2210918C1BB7DB448B5 /* AFURLSessionManager.h */,
-				8EEF297308E4806240A577F9 /* AFURLSessionManager.m */,
-			);
-			name = NSURLSession;
-			sourceTree = "<group>";
-		};
-		BC671178481370A837CF6436 /* Targets Support Files */ = {
-			isa = PBXGroup;
-			children = (
-				9024A8A83FA32FFF97489FD4 /* Pods-EditorDemo */,
-				ACCC039B763AEF1E47543E5E /* Pods-EditorDemoTests */,
-			);
-			name = "Targets Support Files";
-			sourceTree = "<group>";
-		};
-		BCFBD51D6D8D3153A10B4B79 /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				04FA2B1AA8B4A5E188F32C2F /* WordPress-iOS-Shared.bundle */,
-				68591B6C1D914577D1E61C9C /* libPods-EditorDemo.a */,
-				02CB79961772C1D3C1C0B32F /* libPods-EditorDemo-AFNetworking.a */,
-				60160A647A4C6DA0086E5409 /* libPods-EditorDemo-CocoaLumberjack.a */,
-				1BB5DD4596CB66A5A3FCB618 /* libPods-EditorDemo-NSObject-SafeExpectations.a */,
-				45F7A08C76F84BCB288E202F /* libPods-EditorDemo-UIAlertView+Blocks.a */,
-				9C5C3884916463A51CB01472 /* libPods-EditorDemo-WordPress-iOS-Editor.a */,
-				1D176147CF7DAE7F8D372DF5 /* libPods-EditorDemo-WordPress-iOS-Shared.a */,
-				1A9E846D20EEEA4C182CDFB5 /* libPods-EditorDemo-WordPressCom-Analytics-iOS.a */,
-				EC1590E1BC559108B7931F2B /* libPods-EditorDemoTests.a */,
-				3ACB4A9A875522B4D969989F /* libPods-EditorDemoTests-CocoaLumberjack.a */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
-		C1E27A5763FA6E83E49A2298 /* WordPress-iOS-Editor */ = {
-			isa = PBXGroup;
-			children = (
-				59B5C1DEBC58FF11FBFA8073 /* Classes */,
-				EA0EED9C903D108E9B3C390B /* Resources */,
-				77F55B60D5EA1ADEB08C480E /* Support Files */,
+				0DC653B5389BA3B57376BEA5 /* Classes */,
+				3F056102C6DCD741DFA0636C /* Resources */,
+				88BD383B10C890563FDBF892 /* Support Files */,
 			);
 			name = "WordPress-iOS-Editor";
 			path = ../..;
 			sourceTree = "<group>";
 		};
-		CA783A7FFB461DEFA221B616 /* Reachability */ = {
+		54F9F909ADBDA3DE1D464EB2 /* Support Files */ = {
 			isa = PBXGroup;
 			children = (
-				DECA1FA5912BF385D4C72FBA /* AFNetworkReachabilityManager.h */,
-				EF8E2060D208EF60883E9394 /* AFNetworkReachabilityManager.m */,
+				9A59A5E80A2B8C1880C06910 /* Pods-EditorDemo-UIAlertView+Blocks.xcconfig */,
+				D8533A19FBA3CA1A2209E485 /* Pods-EditorDemo-UIAlertView+Blocks-Private.xcconfig */,
+				2FC4A195DA0EB213FF64569A /* Pods-EditorDemo-UIAlertView+Blocks-dummy.m */,
+				A7D25E3367BF6BD686EFE36B /* Pods-EditorDemo-UIAlertView+Blocks-prefix.pch */,
 			);
-			name = Reachability;
+			name = "Support Files";
+			path = "../Target Support Files/Pods-EditorDemo-UIAlertView+Blocks";
 			sourceTree = "<group>";
 		};
-		CC46C0679E035EE3B53AC0D5 /* Support Files */ = {
+		5934D96AA03DFDCE010DCD10 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				5A018DAB5EDC244F76FF62EF /* Pods-EditorDemo-WordPressCom-Analytics-iOS.xcconfig */,
-				4DAD4EFB895576377C6D6421 /* Pods-EditorDemo-WordPressCom-Analytics-iOS-Private.xcconfig */,
-				A6BFF4669D8CBC787478BC99 /* Pods-EditorDemo-WordPressCom-Analytics-iOS-dummy.m */,
-				7406B0C79E10BBAC874DA0BE /* Pods-EditorDemo-WordPressCom-Analytics-iOS-prefix.pch */,
+				C263801747948D9571F0616C /* iOS */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		763AEC0A4EDA3DEBFC2060AE /* Support Files */ = {
+			isa = PBXGroup;
+			children = (
+				6852C355F0448E78E1B00E85 /* Pods-EditorDemo-WordPressCom-Analytics-iOS.xcconfig */,
+				C5FBE421BE6715DE7A8087E9 /* Pods-EditorDemo-WordPressCom-Analytics-iOS-Private.xcconfig */,
+				46F9C8EB1564CC02D7BE58F5 /* Pods-EditorDemo-WordPressCom-Analytics-iOS-dummy.m */,
+				34F665A048D8767C59B6289B /* Pods-EditorDemo-WordPressCom-Analytics-iOS-prefix.pch */,
 			);
 			name = "Support Files";
 			path = "../Target Support Files/Pods-EditorDemo-WordPressCom-Analytics-iOS";
 			sourceTree = "<group>";
 		};
-		CDB4DD9783A0026E3924809E /* Development Pods */ = {
+		7D12450549C896E01DAC9012 /* Support Files */ = {
 			isa = PBXGroup;
 			children = (
-				C1E27A5763FA6E83E49A2298 /* WordPress-iOS-Editor */,
+				EF2B354FCE81E8EBA9DDA2B3 /* Pods-EditorDemo-AFNetworking.xcconfig */,
+				F2C07F7D3B78CFCEAC52945D /* Pods-EditorDemo-AFNetworking-Private.xcconfig */,
+				A8AE6EAD9DC1D6E0427A7141 /* Pods-EditorDemo-AFNetworking-dummy.m */,
+				A1F9A0588FF6B5D8B2BDEDB3 /* Pods-EditorDemo-AFNetworking-prefix.pch */,
 			);
-			name = "Development Pods";
+			name = "Support Files";
+			path = "../Target Support Files/Pods-EditorDemo-AFNetworking";
 			sourceTree = "<group>";
 		};
-		EA0EED9C903D108E9B3C390B /* Resources */ = {
+		80E13B7E8CC431F439E71519 /* Core */ = {
 			isa = PBXGroup;
 			children = (
-				7276D8EF5A1427DA33D3287E /* Assets */,
+				E7C27BA430080E70025E12CD /* DDASLLogCapture.h */,
+				49950677A0673A43329414AE /* DDASLLogCapture.m */,
+				11E91DAED85154EDDD70659B /* DDASLLogger.h */,
+				035B336B3ECB594B6A8A342A /* DDASLLogger.m */,
+				6F9D799883EEAFA57E678C3F /* DDAbstractDatabaseLogger.h */,
+				18FBB2E8FC94F4DD1F05C44B /* DDAbstractDatabaseLogger.m */,
+				737A955B6AB464B3A2DEECD7 /* DDAssertMacros.h */,
+				B47F30258990ECA0D498A47A /* DDFileLogger.h */,
+				A23AF990EA8E1465C5EA2792 /* DDFileLogger.m */,
+				C6953FD23C17AD12497FBB0F /* DDLegacyMacros.h */,
+				459E24005B62319A7867BFB3 /* DDLog.h */,
+				3FC7FAE84FBA1C2DC3791B12 /* DDLog.m */,
+				2BB856A005EC089D8C5D43C8 /* DDLog+LOGV.h */,
+				18A705C1D1A09576152A5618 /* DDLogMacros.h */,
+				3F5A6E8E30BFB77E50AE57EE /* DDTTYLogger.h */,
+				BFF4FBE75092CC85C45662DD /* DDTTYLogger.m */,
 			);
-			name = Resources;
+			name = Core;
 			sourceTree = "<group>";
 		};
-		EAD172B0C58083889931E4BE /* Support Files */ = {
+		88BD383B10C890563FDBF892 /* Support Files */ = {
 			isa = PBXGroup;
 			children = (
-				855236319EC41323955AD9FB /* Pods-EditorDemo-WordPress-iOS-Shared.xcconfig */,
-				CED050E53B65F55252827DB2 /* Pods-EditorDemo-WordPress-iOS-Shared-Private.xcconfig */,
-				47A628B62C503D38F07D5D22 /* Pods-EditorDemo-WordPress-iOS-Shared-dummy.m */,
-				7333CC8C670AC325717EC433 /* Pods-EditorDemo-WordPress-iOS-Shared-prefix.pch */,
+				B9384D5F417CF854217CB608 /* Pods-EditorDemo-WordPress-iOS-Editor.xcconfig */,
+				B9DA7B876D2652FCDAB214CA /* Pods-EditorDemo-WordPress-iOS-Editor-Private.xcconfig */,
+				C103205F3A38A1AFDF27C83C /* Pods-EditorDemo-WordPress-iOS-Editor-dummy.m */,
+				A46A377BA1C610606899CC71 /* Pods-EditorDemo-WordPress-iOS-Editor-prefix.pch */,
+			);
+			name = "Support Files";
+			path = "Example/Pods/Target Support Files/Pods-EditorDemo-WordPress-iOS-Editor";
+			sourceTree = "<group>";
+		};
+		8AB615FB69D625810A69F8C3 /* Targets Support Files */ = {
+			isa = PBXGroup;
+			children = (
+				D956AF0A180971322AA2359A /* Pods-EditorDemo */,
+				AB3BBA8C02B171DA195A73AE /* Pods-EditorDemoTests */,
+			);
+			name = "Targets Support Files";
+			sourceTree = "<group>";
+		};
+		927EF1958F1A3D4963B1828B /* Default */ = {
+			isa = PBXGroup;
+			children = (
+				C72782E3AFB1B33B1F0EB082 /* CocoaLumberjack.h */,
+			);
+			name = Default;
+			sourceTree = "<group>";
+		};
+		A62123F2871D165CB0009EA8 /* NSURLSession */ = {
+			isa = PBXGroup;
+			children = (
+				17836B3819D3E41E6A225C3E /* AFHTTPSessionManager.h */,
+				940F4A009B6C35A94B00B390 /* AFHTTPSessionManager.m */,
+				64F72B8A17254D806052C879 /* AFURLSessionManager.h */,
+				B422F6762B690B55C1EC79AA /* AFURLSessionManager.m */,
+			);
+			name = NSURLSession;
+			sourceTree = "<group>";
+		};
+		A7325CD94957F905D946761D /* AFNetworking */ = {
+			isa = PBXGroup;
+			children = (
+				830D29E461F607EF9E618A7D /* AFNetworking.h */,
+				F6343C9D798519C99EE455F9 /* NSURLConnection */,
+				A62123F2871D165CB0009EA8 /* NSURLSession */,
+				E46964176704278A82E6C4EB /* Reachability */,
+				EE25E1956FC1305423151A54 /* Security */,
+				C150B23CBC6C17CDF7742C7B /* Serialization */,
+				7D12450549C896E01DAC9012 /* Support Files */,
+				F75F6351921223BCD840FD2C /* UIKit */,
+			);
+			path = AFNetworking;
+			sourceTree = "<group>";
+		};
+		AB3BBA8C02B171DA195A73AE /* Pods-EditorDemoTests */ = {
+			isa = PBXGroup;
+			children = (
+				AC43F877A2A01161D907B6D8 /* Pods-EditorDemoTests-acknowledgements.markdown */,
+				1467471810E54CD74871A4E3 /* Pods-EditorDemoTests-acknowledgements.plist */,
+				D3B1F964851055DB409A90BB /* Pods-EditorDemoTests-dummy.m */,
+				1FCCA2B00BB1F33D689FB5C4 /* Pods-EditorDemoTests-environment.h */,
+				20FFC3040AD5EA1F30BC554C /* Pods-EditorDemoTests-resources.sh */,
+				EB11CD05067DAEC2892329BD /* Pods-EditorDemoTests.debug.xcconfig */,
+				F5F7833A0169DF03AAF37725 /* Pods-EditorDemoTests.release.xcconfig */,
+			);
+			name = "Pods-EditorDemoTests";
+			path = "Target Support Files/Pods-EditorDemoTests";
+			sourceTree = "<group>";
+		};
+		ADFB81276DE57FD4064EA1E4 /* Support Files */ = {
+			isa = PBXGroup;
+			children = (
+				E5A3AA62FF0A85993BC8A5F0 /* Pods-EditorDemo-NSObject-SafeExpectations.xcconfig */,
+				804362E3A200B38A7E623C87 /* Pods-EditorDemo-NSObject-SafeExpectations-Private.xcconfig */,
+				372E7D52FF1C08DF33E55661 /* Pods-EditorDemo-NSObject-SafeExpectations-dummy.m */,
+				C55D8A64C4DE697A38F55CD6 /* Pods-EditorDemo-NSObject-SafeExpectations-prefix.pch */,
+			);
+			name = "Support Files";
+			path = "../Target Support Files/Pods-EditorDemo-NSObject-SafeExpectations";
+			sourceTree = "<group>";
+		};
+		B0A5F2EFD0927CD504ADCE5E /* UIAlertView+Blocks */ = {
+			isa = PBXGroup;
+			children = (
+				F9AB73690ECF3D21F89D27F4 /* UIAlertView+Blocks.h */,
+				199BD5014705CEACB439CE05 /* UIAlertView+Blocks.m */,
+				54F9F909ADBDA3DE1D464EB2 /* Support Files */,
+			);
+			path = "UIAlertView+Blocks";
+			sourceTree = "<group>";
+		};
+		B5FBC27E49C23D20BED6497E /* Support Files */ = {
+			isa = PBXGroup;
+			children = (
+				21C47F828590E876B82D76E0 /* Pods-EditorDemo-WordPress-iOS-Shared.xcconfig */,
+				B2445A05A99FF8B7B37E9A00 /* Pods-EditorDemo-WordPress-iOS-Shared-Private.xcconfig */,
+				F8856C375E1B9CD7D48506CA /* Pods-EditorDemo-WordPress-iOS-Shared-dummy.m */,
+				14AE24E316D8F65360CC822D /* Pods-EditorDemo-WordPress-iOS-Shared-prefix.pch */,
 			);
 			name = "Support Files";
 			path = "../Target Support Files/Pods-EditorDemo-WordPress-iOS-Shared";
 			sourceTree = "<group>";
 		};
-		EF3405B9130ECB3F6453BA51 /* UIKit */ = {
+		BF1A0A484ACB01FF16548101 /* NSObject-SafeExpectations */ = {
 			isa = PBXGroup;
 			children = (
-				CDBB1FD933AF6AF88966E053 /* AFNetworkActivityIndicatorManager.h */,
-				1E5D8ED20A690A5DA0A2E877 /* AFNetworkActivityIndicatorManager.m */,
-				D8204AE0034E79F2CE50C5C8 /* UIActivityIndicatorView+AFNetworking.h */,
-				C62728416E4B3FA0654C4627 /* UIActivityIndicatorView+AFNetworking.m */,
-				62A6F5B4248EC25962376F67 /* UIAlertView+AFNetworking.h */,
-				3DFF8FE68DF9DA0E3299D664 /* UIAlertView+AFNetworking.m */,
-				52ED6F51521BD3D073AD7AD4 /* UIButton+AFNetworking.h */,
-				D27F9BD3C4703DA8BD2AC9FB /* UIButton+AFNetworking.m */,
-				4B28F424A4945347088E67AA /* UIImageView+AFNetworking.h */,
-				E55DD7A1E3B91C809FA29A87 /* UIImageView+AFNetworking.m */,
-				308AB52F92CBCF1CA62FEBCB /* UIKit+AFNetworking.h */,
-				03307AB3857022B32EA286FF /* UIProgressView+AFNetworking.h */,
-				A27F58444DE8AE0E76350099 /* UIProgressView+AFNetworking.m */,
-				433ED554028EF4893CAB653F /* UIRefreshControl+AFNetworking.h */,
-				2F99BB982CA76B351FD5E532 /* UIRefreshControl+AFNetworking.m */,
-				52AD4EC065836A821A33C0DA /* UIWebView+AFNetworking.h */,
-				929BBF73903E060609B90773 /* UIWebView+AFNetworking.m */,
+				7754A6100490930D0A6F22A2 /* NSDictionary+SafeExpectations.h */,
+				37AAC3B7B3A2C70273F4B3D2 /* NSDictionary+SafeExpectations.m */,
+				1D5E3538FDAB7AD423034561 /* NSObject+SafeExpectations.h */,
+				ADFB81276DE57FD4064EA1E4 /* Support Files */,
 			);
-			name = UIKit;
+			path = "NSObject-SafeExpectations";
 			sourceTree = "<group>";
 		};
-		F304D0AB18542C6FB8D19246 /* Security */ = {
+		C150B23CBC6C17CDF7742C7B /* Serialization */ = {
 			isa = PBXGroup;
 			children = (
-				DFC722E6F6F78F683ECC3D33 /* AFSecurityPolicy.h */,
-				C92A8CEBF014239853F143AB /* AFSecurityPolicy.m */,
+				3E468D9FFDAE323AC5151DE2 /* AFURLRequestSerialization.h */,
+				C6805C816ED05AC8A28D47E4 /* AFURLRequestSerialization.m */,
+				331E0B9FC63B0EB5802BCC21 /* AFURLResponseSerialization.h */,
+				558641644DB1BF02BEB5DC0F /* AFURLResponseSerialization.m */,
+			);
+			name = Serialization;
+			sourceTree = "<group>";
+		};
+		C263801747948D9571F0616C /* iOS */ = {
+			isa = PBXGroup;
+			children = (
+				94393AB1696E6A7F79B8DFAF /* CoreGraphics.framework */,
+				1715BBEFB6401E99EA712D71 /* Foundation.framework */,
+				28775F67E478EDD244AE7627 /* MobileCoreServices.framework */,
+				7F53F9D8EB84F95DEE41E54D /* Security.framework */,
+				042F776A7301B5A6AB041FEC /* SystemConfiguration.framework */,
+			);
+			name = iOS;
+			sourceTree = "<group>";
+		};
+		D956AF0A180971322AA2359A /* Pods-EditorDemo */ = {
+			isa = PBXGroup;
+			children = (
+				D90FF56905C99BB94F84E117 /* Pods-EditorDemo-acknowledgements.markdown */,
+				2B46CD62B020877E8FB677F2 /* Pods-EditorDemo-acknowledgements.plist */,
+				A202938EC1CAF9A2894E9DD0 /* Pods-EditorDemo-dummy.m */,
+				98293A40B63B4D47CA75A7AE /* Pods-EditorDemo-environment.h */,
+				F80F6772DCA607F7CBC181C7 /* Pods-EditorDemo-resources.sh */,
+				6A98ABB91F55F02BCDFEF6BA /* Pods-EditorDemo.debug.xcconfig */,
+				EEFB446E2FD00B86FE17D354 /* Pods-EditorDemo.release.xcconfig */,
+			);
+			name = "Pods-EditorDemo";
+			path = "Target Support Files/Pods-EditorDemo";
+			sourceTree = "<group>";
+		};
+		E46964176704278A82E6C4EB /* Reachability */ = {
+			isa = PBXGroup;
+			children = (
+				6E8DC67E9E5090F63319260D /* AFNetworkReachabilityManager.h */,
+				7E40A3436DCC6C41C855EF10 /* AFNetworkReachabilityManager.m */,
+			);
+			name = Reachability;
+			sourceTree = "<group>";
+		};
+		E9C808C73F49A6E56A95B862 /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				2E66D244D542F23A3C2B98C2 /* DDContextFilterLogFormatter.h */,
+				B11EEE44A00709A906D350E0 /* DDContextFilterLogFormatter.m */,
+				77241CD57509022AF218143E /* DDDispatchQueueLogFormatter.h */,
+				07FAE5BC824445454A51531B /* DDDispatchQueueLogFormatter.m */,
+				17AFACC2BDB34CFFF477DD38 /* DDMultiFormatter.h */,
+				F1C04F3F3D4AD90EC1CF60C6 /* DDMultiFormatter.m */,
+			);
+			name = Extensions;
+			sourceTree = "<group>";
+		};
+		ECE72B6DBBE8F00DD6BCDD37 /* Assets */ = {
+			isa = PBXGroup;
+			children = (
+				2669244F4C29C037108616F3 /* WPHybridCallbacker.js */,
+				0A6C6981CB3A9AB208AF5077 /* WPHybridLogger.js */,
+				DA1ABCA6BB1A3811A9EC9985 /* ZSSRichTextEditor.js */,
+				F9B4EF0414A8CD0025050E0A /* ZSSbgcolor.png */,
+				C1B9353D016D5F5C1CD1488B /* ZSSbgcolor@2x.png */,
+				81A89E9F59F0D078E8D4E90F /* ZSScenterjustify.png */,
+				BA62D90FEA53B27B7AE7B24F /* ZSScenterjustify@2x.png */,
+				856DAB3458CD20E190080D02 /* ZSSclearstyle.png */,
+				80C3BFD36B90F05B774A99D7 /* ZSSclearstyle@2x.png */,
+				91ABD55B7DDE2A9FE545EFFE /* ZSSforcejustify.png */,
+				21DB075E84A404505D765751 /* ZSSforcejustify@2x.png */,
+				A880B57A5429CEF2C758AC91 /* ZSSh1.png */,
+				57B573EE6EE4B8A2D1AB2638 /* ZSSh1@2x.png */,
+				144E096C30FCE5B9ED0E4745 /* ZSSh2.png */,
+				19F2F93215C85CCACB2C8711 /* ZSSh2@2x.png */,
+				60D844A00647ED2C3508F964 /* ZSSh3.png */,
+				8EFE5084F4569412038D7BF7 /* ZSSh3@2x.png */,
+				8F49C8748333FFF4261DECC6 /* ZSSh4.png */,
+				69CCB1A9A961BE8BC09AB9F3 /* ZSSh4@2x.png */,
+				173EFF3D168DF9D6CB096083 /* ZSSh5.png */,
+				9042126015EA1889026A8E54 /* ZSSh5@2x.png */,
+				80302E9B4537ECB6EF286F65 /* ZSSh6.png */,
+				9842E60B14C6412B7366C96C /* ZSSh6@2x.png */,
+				33DD6C763204232C4ED4802B /* ZSShorizontalrule.png */,
+				61006414E39A528C4E58750D /* ZSShorizontalrule@2x.png */,
+				50339097B8CBC5E886B6D725 /* ZSSindent.png */,
+				C045E87560C5D5C18C9E4348 /* ZSSindent@2x.png */,
+				8DD9BC7FDB3B0355D30E9E0D /* ZSSleftjustify.png */,
+				618C257A9F2380A5ABE4F155 /* ZSSleftjustify@2x.png */,
+				61E0D674159B1D208B6ABAD8 /* ZSSoutdent.png */,
+				8E0332AA34CBB34D2AA96BE8 /* ZSSoutdent@2x.png */,
+				1A2D8BDD76F6A5CBC9F5261C /* ZSSquicklink.png */,
+				002154DF256B9144662854F6 /* ZSSquicklink@2x.png */,
+				DEB52D0CD09739AEE7E3DAC3 /* ZSSredo.png */,
+				B2C72AB408256C2ED5FCABE4 /* ZSSredo@2x.png */,
+				A0F250D3BB9218077B8EBF56 /* ZSSrightjustify.png */,
+				DBEC760F3CC8F9204DB95D6D /* ZSSrightjustify@2x.png */,
+				59CFC3C3787398193949FD23 /* ZSSsubscript.png */,
+				BE75D030229DE640D09F07F8 /* ZSSsubscript@2x.png */,
+				CDA3414F53DB1756DB583319 /* ZSSsuperscript.png */,
+				B90BD7F531876B3FF3B4C90E /* ZSSsuperscript@2x.png */,
+				F64D00770C289DCCC3ADD806 /* ZSStextcolor.png */,
+				3B01E0BF692F74633041F2C8 /* ZSStextcolor@2x.png */,
+				D1FBB843E22CF9F8D635CF8D /* ZSSundo.png */,
+				F8917F269CE4458D3BED71A2 /* ZSSundo@2x.png */,
+				00BF11F0F937DCF9D754D429 /* editor.css */,
+				19170C331BCCE321FE86CD4E /* editor.html */,
+				042A4BC8EC33097B7112E4E4 /* icon-posts-editor-inspector.png */,
+				508CF2FF147199EDE0723309 /* icon-posts-editor-inspector@2x.png */,
+				9B18C48B89649646EFFEC8EE /* icon-posts-editor-inspector@3x.png */,
+				1EDE70E77E6648CB61DA42CE /* icon-posts-editor-preview.png */,
+				53792216D7D30CEB563A411E /* icon-posts-editor-preview@2x.png */,
+				23DAB0AF2138D2938B81C209 /* icon-posts-editor-preview@3x.png */,
+				97B98167D74764B5BDACB9AD /* icon_format_bold.png */,
+				470F24E815401928FD955EB3 /* icon_format_bold@2x.png */,
+				955EA642B62D7FA7676DB7D7 /* icon_format_bold@3x.png */,
+				8BF2AD80274A9014FCDA0179 /* icon_format_html.png */,
+				1CF756A4E117BC1ADDD7961B /* icon_format_html@2x.png */,
+				C4AF95B320D7BBEADEB26E1C /* icon_format_html@3x.png */,
+				A432A3184956447B5213C54D /* icon_format_italic.png */,
+				CC9D574E384F52B696DE17D8 /* icon_format_italic@2x.png */,
+				F0F84B0A2337008BFEC8305B /* icon_format_italic@3x.png */,
+				4BDE5D7F2637C29BC2E2C79D /* icon_format_keyboard.png */,
+				83E63C23734D05C5F7D84FFB /* icon_format_keyboard@2x.png */,
+				9900653897AC272CF5E46CE7 /* icon_format_link.png */,
+				50A6753DC213E299ED70D9B2 /* icon_format_link@2x.png */,
+				14FAEE7679908D8D4E78E82D /* icon_format_link@3x.png */,
+				4DC9D69691F2040AE1AE5DC7 /* icon_format_media.png */,
+				F332E993DF63EE57033387E2 /* icon_format_media@2x.png */,
+				6C955FC153161B3415581076 /* icon_format_media@3x.png */,
+				845A813DEB80571DF4A6253A /* icon_format_more.png */,
+				F601B5F2BBDB10B9C92E1F2B /* icon_format_more@2x.png */,
+				06183EBBC512138990CDA43A /* icon_format_more@3x.png */,
+				B899899B2D176B9218A6EEE0 /* icon_format_ol.png */,
+				A09C046F3AA114F182E3CE20 /* icon_format_ol@2x.png */,
+				9C58B70512F65A1952BBB06D /* icon_format_ol@3x.png */,
+				E0D406C0EB0F7A314F8E4706 /* icon_format_quote.png */,
+				462A898F904BC55A27F74B98 /* icon_format_quote@2x.png */,
+				4E315DF24D4044B7F83F9CEB /* icon_format_quote@3x.png */,
+				F719137B3A33761B4EBE8024 /* icon_format_strikethrough.png */,
+				723BC3DF7F0C51B0FAA1836E /* icon_format_strikethrough@2x.png */,
+				12AA85A80517CD6A41F53C45 /* icon_format_strikethrough@3x.png */,
+				07BE82A30BE140F5FBA496B2 /* icon_format_ul.png */,
+				D650A0A75C9D9C5AAB53A554 /* icon_format_ul@2x.png */,
+				1F0315D2417746F806EEE93F /* icon_format_ul@3x.png */,
+				323C2D888D8D00B6B4460635 /* icon_format_underline.png */,
+				6992D1169C726D17CA37099F /* icon_format_underline@2x.png */,
+				6D533419F7F6ACD8998B4A9E /* icon_format_unlink.png */,
+				247B65CB971D5625EDD4D07F /* icon_format_unlink@2x.png */,
+				E445EAD7079FB1D560FA0FCB /* icon_options.png */,
+				88D1C5871925C98B76AC8B91 /* icon_options@2x.png */,
+				44CA4CDDD7EDD50E21DED3DF /* icon_preview.png */,
+				E2A1D7EC00921340BB6617F9 /* icon_preview@2x.png */,
+				B601337600D2A5E61998CB85 /* jquery.js */,
+				DF1935770CBFEFA76E573974 /* jquery.mobile-events.min.js */,
+				01F1CBD60F6C20CB7E44D7A9 /* js-beautifier.js */,
+				507B500CC9F77BA3A2B0914F /* rangy-classapplier.js */,
+				A256E763365F8356EFA37C3C /* rangy-core.js */,
+				9240B509809EAFE71B4FC987 /* rangy-highlighter.js */,
+				91AA5F7A46E7DCF32B6B87FD /* rangy-selectionsaverestore.js */,
+				E0C5151DF40930A4D47E94E8 /* rangy-serializer.js */,
+				171117ED200E1725AC9E49EC /* rangy-textrange.js */,
+				D58823FC4526B2C3BC865271 /* shortcode.js */,
+				D986604F98202B97779F9A36 /* underscore-min.js */,
+				75CEEE89768D66DEAD93AAB8 /* wpload.js */,
+				F7705589E47D909A0E8CCF65 /* wpposter.svg */,
+				1CCAE57FEC1C895A4E96866F /* wpsave.js */,
+			);
+			path = Assets;
+			sourceTree = "<group>";
+		};
+		EE25E1956FC1305423151A54 /* Security */ = {
+			isa = PBXGroup;
+			children = (
+				2ED670FD22CA40E59803C5DA /* AFSecurityPolicy.h */,
+				2849F0104A3F2D6D00745B1D /* AFSecurityPolicy.m */,
 			);
 			name = Security;
 			sourceTree = "<group>";
 		};
-		FCA490EA19E24FF762ECA95A /* CocoaLumberjack */ = {
+		F6343C9D798519C99EE455F9 /* NSURLConnection */ = {
 			isa = PBXGroup;
 			children = (
-				2E63555956F325130352EF77 /* Core */,
-				0872BB9053EDF9654D42C496 /* Default */,
-				A59D65AE3D1055424F12B301 /* Extensions */,
-				426A8B32F731C9424DD25E82 /* Support Files */,
+				8673BA9704033A8EDE356D91 /* AFHTTPRequestOperation.h */,
+				0F282BBD8F9CEAA3F56CFACF /* AFHTTPRequestOperation.m */,
+				DC187FBCD9C194FA06A35129 /* AFHTTPRequestOperationManager.h */,
+				37FA504A49AC5684EF946CBD /* AFHTTPRequestOperationManager.m */,
+				7B4BEB1ED0D87B02894A937B /* AFURLConnectionOperation.h */,
+				035D98E3238B5312570CDE80 /* AFURLConnectionOperation.m */,
 			);
-			path = CocoaLumberjack;
+			name = NSURLConnection;
+			sourceTree = "<group>";
+		};
+		F75F6351921223BCD840FD2C /* UIKit */ = {
+			isa = PBXGroup;
+			children = (
+				1A22270E1206E29078682CCB /* AFNetworkActivityIndicatorManager.h */,
+				EAC99E4AE0F997449AD088F4 /* AFNetworkActivityIndicatorManager.m */,
+				F6D4DB0B4FBE1F6A662937D5 /* UIActivityIndicatorView+AFNetworking.h */,
+				311C6EDA025611DECCA08315 /* UIActivityIndicatorView+AFNetworking.m */,
+				58A390AA3878ED244AF4145F /* UIAlertView+AFNetworking.h */,
+				F92539183359EB4FF19CD625 /* UIAlertView+AFNetworking.m */,
+				3E6FC2D20653D35A47ABB183 /* UIButton+AFNetworking.h */,
+				BBA4062FEA14CA197DA5B036 /* UIButton+AFNetworking.m */,
+				E3A69BFB86F47ADB12091BB6 /* UIImageView+AFNetworking.h */,
+				28868A31B71EE7737F86D101 /* UIImageView+AFNetworking.m */,
+				605D515A3EF49FA9807F52E2 /* UIKit+AFNetworking.h */,
+				C94387FAC53D4EF4B2DDDAE4 /* UIProgressView+AFNetworking.h */,
+				CCD50474AD55C76E4C71F5C6 /* UIProgressView+AFNetworking.m */,
+				341CC9FE4B6F4A8B762446E2 /* UIRefreshControl+AFNetworking.h */,
+				4C42ED855F0AE2EDAA16A5D8 /* UIRefreshControl+AFNetworking.m */,
+				D8AF1A872FF52CB9CD476958 /* UIWebView+AFNetworking.h */,
+				1D5487200DB87D47FC5C41C6 /* UIWebView+AFNetworking.m */,
+			);
+			name = UIKit;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
-		103AB016E8C5E291D456AE20 /* Headers */ = {
+		45AF20E6725148998F3BFAE7 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				8725DD98031BE3CBA839D67A /* NSDictionary+SafeExpectations.h in Headers */,
-				B15CDB92D498DC63C3669B58 /* NSObject+SafeExpectations.h in Headers */,
+				087BCAEFA37468C79A3B0069 /* NSString+Util.h in Headers */,
+				E6ECBF0772F8DDB8474EEE7C /* NSString+XMLExtensions.h in Headers */,
+				BFEAECAA34F8A822AE1244F3 /* UIColor+Helpers.h in Headers */,
+				00EACB7821F28A5604C335D0 /* UIImage+Util.h in Headers */,
+				66006C47AE6A612215C18B6C /* UITableViewTextFieldCell.h in Headers */,
+				4C33EF1B6D15BBB80E8124B2 /* WPAnimatedImageResponseSerializer.h in Headers */,
+				9C20D2FCDA2FCE9EA4DA2EE3 /* WPDeviceIdentification.h in Headers */,
+				3B1A90CA5EBDBCCF4C5784A6 /* WPFontManager.h in Headers */,
+				E61E58E633BE54390F5DA65F /* WPImageSource.h in Headers */,
+				CA4FA5D4995CE106BB783588 /* WPNUXUtility.h in Headers */,
+				2EB9FF3EBEA1AD9DDB0981D3 /* WPNoResultsView.h in Headers */,
+				2FF2C3AD24039BFC59EAD3B2 /* WPStyleGuide.h in Headers */,
+				F47FBBA60C955096F308DC1F /* WPTableViewCell.h in Headers */,
+				A5DEACDC0E390C8E22988AA0 /* WPTableViewSectionFooterView.h in Headers */,
+				D113A979106AFADF3E769DE3 /* WPTableViewSectionHeaderView.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		1CCAA28CE39376239BF21858 /* Headers */ = {
+		4F876619D34DBFF097AEF336 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				E8B5B320F2EBBBE7FDBFE363 /* AFHTTPRequestOperation.h in Headers */,
-				B6BC073B5BC15EDCA96DBDD8 /* AFHTTPRequestOperationManager.h in Headers */,
-				E56666F7DBCE6128F58A3564 /* AFHTTPSessionManager.h in Headers */,
-				B5073CEB582B7CBE8E97B959 /* AFNetworkActivityIndicatorManager.h in Headers */,
-				FE14057D1C15D165C8A6C72D /* AFNetworkReachabilityManager.h in Headers */,
-				99FF042154967FC4B4149418 /* AFNetworking.h in Headers */,
-				237E2D37AEB16704A553434A /* AFSecurityPolicy.h in Headers */,
-				5C2162DA09250C24CB89E11F /* AFURLConnectionOperation.h in Headers */,
-				C1E6914A21C78F65D653E968 /* AFURLRequestSerialization.h in Headers */,
-				917C876E258FF870B41E4BE9 /* AFURLResponseSerialization.h in Headers */,
-				1C28F6C7964ACB9C77491AE7 /* AFURLSessionManager.h in Headers */,
-				D1815F66707258EB336AFFA4 /* UIActivityIndicatorView+AFNetworking.h in Headers */,
-				14FFAB7D0B650855CA83819A /* UIAlertView+AFNetworking.h in Headers */,
-				1A18695751BE30544DE70F7B /* UIButton+AFNetworking.h in Headers */,
-				BF263C8F625E32DBAFC0B273 /* UIImageView+AFNetworking.h in Headers */,
-				2DD5BCF8D9F00B5DCF0245F0 /* UIKit+AFNetworking.h in Headers */,
-				8F204FF966AD8B208DD0A0E8 /* UIProgressView+AFNetworking.h in Headers */,
-				69EB6174C3B4193515FDE7EF /* UIRefreshControl+AFNetworking.h in Headers */,
-				3955A7B079EE33C604A49AB0 /* UIWebView+AFNetworking.h in Headers */,
+				265E502EE5AD1B6920FEF301 /* CYRLayoutManager.h in Headers */,
+				FD79394D3DD06D07D67DAE21 /* CYRTextStorage.h in Headers */,
+				E1F43BF89EB0DDD9D8E2C4FC /* CYRTextView.h in Headers */,
+				5A4E733842D7574E5ACD7049 /* CYRToken.h in Headers */,
+				5690DC123A170E12C141E5C1 /* HRBrightnessCursor.h in Headers */,
+				D85D7700AE58F528C429F0E4 /* HRCgUtil.h in Headers */,
+				0678FD38EDC7B6368A846A94 /* HRColorCursor.h in Headers */,
+				3841FA571435911B393A3EA6 /* HRColorPickerMacros.h in Headers */,
+				20A7036A9B13188247DEABE1 /* HRColorPickerView.h in Headers */,
+				5E4A81CEBDF75A3E45A3FE6B /* HRColorPickerViewController.h in Headers */,
+				5C3FC1803741E21BEBA4CD96 /* HRColorUtil.h in Headers */,
+				D928667F03F0873DB5641670 /* UIWebView+GUIFixes.h in Headers */,
+				B50899E9D868142861284800 /* WPEditorField.h in Headers */,
+				40150A015D44DCC879F2B267 /* WPEditorLoggingConfiguration.h in Headers */,
+				26B63962D93E8C57912D3673 /* WPEditorToolbarButton.h in Headers */,
+				B6EB43F030B950FA98B7BFC8 /* WPEditorToolbarView.h in Headers */,
+				DDAFFCF0E39BDD97834FB42A /* WPEditorView.h in Headers */,
+				C3958D8C5D54BC51ABEB1219 /* WPEditorViewController.h in Headers */,
+				5331834C1D64D40F4A387598 /* WPImageMeta.h in Headers */,
+				51925EAFFD9C5D45D5430D31 /* WPLegacyEditorViewController.h in Headers */,
+				D7B1AA9E2C6854631A7C855E /* WPLegacyKeyboardToolbarBase.h in Headers */,
+				4BF6ACC1FD6B68EEB8AECD84 /* WPLegacyKeyboardToolbarButtonItem.h in Headers */,
+				B9C54AF9ED59EBDFA8D20F91 /* WPLegacyKeyboardToolbarDone.h in Headers */,
+				35C586DBF19F15B25A53C307 /* ZSSBarButtonItem.h in Headers */,
+				BFCF75B544C536E11F558402 /* ZSSTextView.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		286D083DA6EF41491B199E93 /* Headers */ = {
+		826A460D3C3AFE0790E7EBC8 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				71E668178A0A56D58CFE4385 /* CYRLayoutManager.h in Headers */,
-				D7BF96479AEB6DFF02378851 /* CYRTextStorage.h in Headers */,
-				3D7CDF7525DCF86806FA1A80 /* CYRTextView.h in Headers */,
-				CB88DD0B0EA1AB9191230CE6 /* CYRToken.h in Headers */,
-				C0AFFBDE81608A5CB35CC881 /* HRBrightnessCursor.h in Headers */,
-				5DA1FDF0605F8B3A6681E522 /* HRCgUtil.h in Headers */,
-				89E0E324AFB12A2A735FE947 /* HRColorCursor.h in Headers */,
-				CD2060C74AB6D09E4386EAFA /* HRColorPickerMacros.h in Headers */,
-				7F9B7B6C92BBEBDC2777FD3A /* HRColorPickerView.h in Headers */,
-				1A5ACF89528586C976AC9899 /* HRColorPickerViewController.h in Headers */,
-				AFF7AEA94838565FC0DE4196 /* HRColorUtil.h in Headers */,
-				36C4082C5A62A93021A2C46A /* UIWebView+GUIFixes.h in Headers */,
-				D6C7CA58C892E2E26C66E48F /* WPEditorField.h in Headers */,
-				0A89547B2C05361CEC274F63 /* WPEditorLoggingConfiguration.h in Headers */,
-				227248CA6CD7A79475224DAB /* WPEditorToolbarButton.h in Headers */,
-				91F54F28ADAD33EB4927C1CC /* WPEditorToolbarView.h in Headers */,
-				1751BC98C04280BBF48720E6 /* WPEditorView.h in Headers */,
-				B6A5C66616BF39D655087172 /* WPEditorViewController.h in Headers */,
-				E73055EAB6F88901B0F7EE62 /* WPImageMeta.h in Headers */,
-				B32A76314129462DEFB82944 /* WPLegacyEditorViewController.h in Headers */,
-				7202887560AFA7ADD7572AFE /* WPLegacyKeyboardToolbarBase.h in Headers */,
-				9CDC135567217FBCE92A0C53 /* WPLegacyKeyboardToolbarButtonItem.h in Headers */,
-				78D837083E1BD7C24E9EE23F /* WPLegacyKeyboardToolbarDone.h in Headers */,
-				F7F27FACC6AF47C9939727B1 /* ZSSBarButtonItem.h in Headers */,
-				CD4BDE29C5FFC1013B08FC8C /* ZSSTextView.h in Headers */,
+				49ACCB357615B4CEBCE11181 /* NSDictionary+SafeExpectations.h in Headers */,
+				3F951707702C9D751319C4B9 /* NSObject+SafeExpectations.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		2D4CE65A08656AD9D6803CB9 /* Headers */ = {
+		8A219E9E8091C80683CB4C8D /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				7F5221144D0E5C033AB0E23A /* CocoaLumberjack.h in Headers */,
-				3CCDF32D30DC8B6031A75A28 /* DDASLLogCapture.h in Headers */,
-				87C27ECAFA60B74EB62B71E5 /* DDASLLogger.h in Headers */,
-				DE8063EC0AE193C2E0EBF6A6 /* DDAbstractDatabaseLogger.h in Headers */,
-				46FC19FD4A98A96DFA00514B /* DDAssertMacros.h in Headers */,
-				E73503A5CA850B4EB263D594 /* DDContextFilterLogFormatter.h in Headers */,
-				7A92D46090BA61F891D06EC8 /* DDDispatchQueueLogFormatter.h in Headers */,
-				C2316F9979DD7BBA4D3E688F /* DDFileLogger.h in Headers */,
-				3C3533D02DD976914780025B /* DDLegacyMacros.h in Headers */,
-				820476BEF888886774F2589C /* DDLog+LOGV.h in Headers */,
-				E3CC00ED2F3790D318243726 /* DDLog.h in Headers */,
-				BEBE39218171BC7FA3C9BA5B /* DDLogMacros.h in Headers */,
-				122EC76C9FC417183CFC3624 /* DDMultiFormatter.h in Headers */,
-				FE8B0D33557734A70A37B024 /* DDTTYLogger.h in Headers */,
+				5EFDDC9C170F7A7BE41B666A /* CocoaLumberjack.h in Headers */,
+				F1F002C96F141C844E260262 /* DDASLLogCapture.h in Headers */,
+				0CFD44BBF2ACE66FC66876E3 /* DDASLLogger.h in Headers */,
+				C9690BA45AC64A6EA053D6B2 /* DDAbstractDatabaseLogger.h in Headers */,
+				CCCCD1DFA002B0A4BC92FDED /* DDAssertMacros.h in Headers */,
+				665078E8CB067A5A83DBC8D0 /* DDContextFilterLogFormatter.h in Headers */,
+				8A2FE5CE1AA54A256029D793 /* DDDispatchQueueLogFormatter.h in Headers */,
+				1CDE6EFB5B9278EA6D873930 /* DDFileLogger.h in Headers */,
+				7B0D8D1D91CA6BB393EDCE9B /* DDLegacyMacros.h in Headers */,
+				632B4277B4D76246ADAA3731 /* DDLog+LOGV.h in Headers */,
+				4947305BC71AA2E94669302C /* DDLog.h in Headers */,
+				7D2FA67057C979CB3BD6E1FD /* DDLogMacros.h in Headers */,
+				CB220B86C9A81F2C61542528 /* DDMultiFormatter.h in Headers */,
+				4F3002AE2E1E312696A858A7 /* DDTTYLogger.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		314EB762295209DFE595C206 /* Headers */ = {
+		8D6ECB20ED9ED2A2E11AF668 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				020A23EB755E373D0C774FC4 /* CocoaLumberjack.h in Headers */,
-				779DD46D883D5F4E465C2436 /* DDASLLogCapture.h in Headers */,
-				880426EE3396B78733596F3A /* DDASLLogger.h in Headers */,
-				623DE47FBB54662F2DF11DCF /* DDAbstractDatabaseLogger.h in Headers */,
-				12C2BD102767B4BC14379682 /* DDAssertMacros.h in Headers */,
-				E8347C53F5D8070FB7767B18 /* DDContextFilterLogFormatter.h in Headers */,
-				C4BA77E8350D2F83778F2DCC /* DDDispatchQueueLogFormatter.h in Headers */,
-				DF430A365E88AEA8C53FD9D5 /* DDFileLogger.h in Headers */,
-				2CEFDCB0FE3DB2F3C6DF498D /* DDLegacyMacros.h in Headers */,
-				245FD6C1DA22B17EC2F2FC3A /* DDLog+LOGV.h in Headers */,
-				C16A8EF683F5BBE375328608 /* DDLog.h in Headers */,
-				ABDB15436BE40C6FF57DEEA0 /* DDLogMacros.h in Headers */,
-				C98E9D324188C3C118264584 /* DDMultiFormatter.h in Headers */,
-				71580D39779F6D913C47D0EB /* DDTTYLogger.h in Headers */,
+				13CCBAD9E4B5E68BBBCAB4AB /* CocoaLumberjack.h in Headers */,
+				DF7C65731C265AA055158661 /* DDASLLogCapture.h in Headers */,
+				3C39D9AA17DD2976390423A0 /* DDASLLogger.h in Headers */,
+				1C4808DF15B1E4FAE726E77D /* DDAbstractDatabaseLogger.h in Headers */,
+				214FF1C9E8E55F2FDC5CA1B2 /* DDAssertMacros.h in Headers */,
+				AAB9802A3772474A932F3A58 /* DDContextFilterLogFormatter.h in Headers */,
+				58F2EDB671C1BCA7B4FDF2D1 /* DDDispatchQueueLogFormatter.h in Headers */,
+				859B9CB333C8C7719E6A1C2F /* DDFileLogger.h in Headers */,
+				245B8BBB4019CD0E1FC55348 /* DDLegacyMacros.h in Headers */,
+				030ECDF1ED13FD94C441B8D2 /* DDLog+LOGV.h in Headers */,
+				37824F02D7B16A549BE2B98C /* DDLog.h in Headers */,
+				32510E954AEDD7929064B07B /* DDLogMacros.h in Headers */,
+				2C3B4719A29463EACF55D3A9 /* DDMultiFormatter.h in Headers */,
+				57BC607CDF29EC50A462F224 /* DDTTYLogger.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		7C13EF88BF9EA25C9CA1C527 /* Headers */ = {
+		BAE30766D4834A8671DDF712 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				5F90574FD42281DB4951457E /* UIAlertView+Blocks.h in Headers */,
+				265A082E9E4CE2831BFE4846 /* AFHTTPRequestOperation.h in Headers */,
+				9EC721EAF6E3189F444E267C /* AFHTTPRequestOperationManager.h in Headers */,
+				00B315BA0F840005A32E0273 /* AFHTTPSessionManager.h in Headers */,
+				849DDC4B8CD6000A8D6FE99C /* AFNetworkActivityIndicatorManager.h in Headers */,
+				80374557CD2AC2CF8FA81995 /* AFNetworkReachabilityManager.h in Headers */,
+				D8642EF734E1642582BA0EDF /* AFNetworking.h in Headers */,
+				41040B9C67E75BDB940D56E8 /* AFSecurityPolicy.h in Headers */,
+				A2184FBCBED6E7DE8602041B /* AFURLConnectionOperation.h in Headers */,
+				7C3B2DC1BC16EC8E9AC1FB2B /* AFURLRequestSerialization.h in Headers */,
+				15FED5B86773D58516FB6832 /* AFURLResponseSerialization.h in Headers */,
+				30E0A9BDCC6FA0306F1C9936 /* AFURLSessionManager.h in Headers */,
+				2E11231A7C07813C1242646D /* UIActivityIndicatorView+AFNetworking.h in Headers */,
+				7F1CCBF721ECF6BFEF54F858 /* UIAlertView+AFNetworking.h in Headers */,
+				4EF58884974D9DC28DB0315A /* UIButton+AFNetworking.h in Headers */,
+				BF4084F7FCAB671A071B4133 /* UIImageView+AFNetworking.h in Headers */,
+				E4A0B7DCE50CB26AF3AE34EB /* UIKit+AFNetworking.h in Headers */,
+				6510CBADBA028F03DB4F47D8 /* UIProgressView+AFNetworking.h in Headers */,
+				1E9F86C4E0ADAE74026F0D81 /* UIRefreshControl+AFNetworking.h in Headers */,
+				14A8DAE9CF6DEAA45AD06B4A /* UIWebView+AFNetworking.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		C1F6B4FE1578D8566358C1A9 /* Headers */ = {
+		D03BA35AD537BF38B47850F8 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BA3B03CE80916430EE504961 /* NSString+Util.h in Headers */,
-				EFB786CC8A93244F0C1ECDCF /* NSString+XMLExtensions.h in Headers */,
-				151A63F36E8CB540E1A1827A /* UIColor+Helpers.h in Headers */,
-				D90FC966267BF90F2A7EE0FA /* UIImage+Util.h in Headers */,
-				C29A8459E1EFF811159DFFE3 /* UITableViewTextFieldCell.h in Headers */,
-				0679D5761D8BCD5A778FFBDB /* WPAnimatedImageResponseSerializer.h in Headers */,
-				B2C9DF76B88C2B8AAD8207EF /* WPDeviceIdentification.h in Headers */,
-				3747CD7DBDB033F9B16FBB52 /* WPFontManager.h in Headers */,
-				ED6CB2637670B71E629F1BF5 /* WPImageSource.h in Headers */,
-				095216B14586964134ED9258 /* WPNUXUtility.h in Headers */,
-				8C43DDF2C38969231D0A4DE3 /* WPNoResultsView.h in Headers */,
-				ABF0A37A746FB45AE5392D10 /* WPStyleGuide.h in Headers */,
-				DC7D83E099F3C93714294186 /* WPTableViewCell.h in Headers */,
-				2C679539F4112C521B2AFACE /* WPTableViewSectionFooterView.h in Headers */,
-				D9889B21DF55981AF2EAE820 /* WPTableViewSectionHeaderView.h in Headers */,
+				1A424E2B5B049C8FAFB83479 /* UIAlertView+Blocks.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		F345234ED8D00466A3F71B92 /* Headers */ = {
+		F042C2C07C2733CFC7D13418 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				2A04A6613CCF60FD474C5811 /* WPAnalytics.h in Headers */,
+				9B0D1847DD97F363225C3E38 /* WPAnalytics.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
-		5B5431C7C77BA40377BC1687 /* Pods-EditorDemo-WordPress-iOS-Shared */ = {
+		0393028516D354A9A4D3EF99 /* Pods-EditorDemo-NSObject-SafeExpectations */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 2FED5201A426698EA0D1289E /* Build configuration list for PBXNativeTarget "Pods-EditorDemo-WordPress-iOS-Shared" */;
+			buildConfigurationList = AA227CC47B3A51AAA6010D9F /* Build configuration list for PBXNativeTarget "Pods-EditorDemo-NSObject-SafeExpectations" */;
 			buildPhases = (
-				5281504B79E68BFF8605F21E /* Sources */,
-				B864EB6909A4CC585E6E2966 /* Frameworks */,
-				C1F6B4FE1578D8566358C1A9 /* Headers */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				6F31C7ED476979DDECF77187 /* PBXTargetDependency */,
-				E78E1DC72E1412A1C0609ECB /* PBXTargetDependency */,
-				970E8B8E0525B61F7BEC62C8 /* PBXTargetDependency */,
-			);
-			name = "Pods-EditorDemo-WordPress-iOS-Shared";
-			productName = "Pods-EditorDemo-WordPress-iOS-Shared";
-			productReference = 1D176147CF7DAE7F8D372DF5 /* libPods-EditorDemo-WordPress-iOS-Shared.a */;
-			productType = "com.apple.product-type.library.static";
-		};
-		684969EABA68BEADF10760C6 /* Pods-EditorDemo-UIAlertView+Blocks */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 46B8FE4256F90758A0033BC3 /* Build configuration list for PBXNativeTarget "Pods-EditorDemo-UIAlertView+Blocks" */;
-			buildPhases = (
-				37DA34DD24DA2A99E6F693D3 /* Sources */,
-				14D8C4491D76D05893E578A5 /* Frameworks */,
-				7C13EF88BF9EA25C9CA1C527 /* Headers */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = "Pods-EditorDemo-UIAlertView+Blocks";
-			productName = "Pods-EditorDemo-UIAlertView+Blocks";
-			productReference = 45F7A08C76F84BCB288E202F /* libPods-EditorDemo-UIAlertView+Blocks.a */;
-			productType = "com.apple.product-type.library.static";
-		};
-		7F986800EA7C868765DE35F0 /* Pods-EditorDemo-WordPressCom-Analytics-iOS */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = E9D3BBD89D8810AB4AB8F64F /* Build configuration list for PBXNativeTarget "Pods-EditorDemo-WordPressCom-Analytics-iOS" */;
-			buildPhases = (
-				8D9EA44DAD922CAA9E2E18B7 /* Sources */,
-				B09794C3E668034045BBC420 /* Frameworks */,
-				F345234ED8D00466A3F71B92 /* Headers */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = "Pods-EditorDemo-WordPressCom-Analytics-iOS";
-			productName = "Pods-EditorDemo-WordPressCom-Analytics-iOS";
-			productReference = 1A9E846D20EEEA4C182CDFB5 /* libPods-EditorDemo-WordPressCom-Analytics-iOS.a */;
-			productType = "com.apple.product-type.library.static";
-		};
-		8370BACC5BF439087B250486 /* Pods-EditorDemoTests */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = F2C219259EF552112F49BEC6 /* Build configuration list for PBXNativeTarget "Pods-EditorDemoTests" */;
-			buildPhases = (
-				ABD661EA8BBB2D9EA712B4F6 /* Sources */,
-				38DC750FF82AE104ABA33E40 /* Frameworks */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				DDB40B615022A8DAEB700EB9 /* PBXTargetDependency */,
-			);
-			name = "Pods-EditorDemoTests";
-			productName = "Pods-EditorDemoTests";
-			productReference = EC1590E1BC559108B7931F2B /* libPods-EditorDemoTests.a */;
-			productType = "com.apple.product-type.library.static";
-		};
-		BEE2D6A907D7AB7A9244F7C1 /* Pods-EditorDemo-AFNetworking */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 8255DBC7EF8E80A76140600F /* Build configuration list for PBXNativeTarget "Pods-EditorDemo-AFNetworking" */;
-			buildPhases = (
-				AE9AFD6513D789D64408716A /* Sources */,
-				27276544C942228E2772FD3C /* Frameworks */,
-				1CCAA28CE39376239BF21858 /* Headers */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = "Pods-EditorDemo-AFNetworking";
-			productName = "Pods-EditorDemo-AFNetworking";
-			productReference = 02CB79961772C1D3C1C0B32F /* libPods-EditorDemo-AFNetworking.a */;
-			productType = "com.apple.product-type.library.static";
-		};
-		CBA62BA361B3BA3988412C3A /* Pods-EditorDemo */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 29F2ACFBADD8E7DBF87BB4B8 /* Build configuration list for PBXNativeTarget "Pods-EditorDemo" */;
-			buildPhases = (
-				14DB1F0873D20DE635DE81B2 /* Sources */,
-				D754C5B832F2AB7859A721CA /* Frameworks */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				A6E8D0425A39945A78A18C94 /* PBXTargetDependency */,
-				989988A536DCC5BAC0563CB3 /* PBXTargetDependency */,
-				BD004CBB9B9896E1E0C1EA9D /* PBXTargetDependency */,
-				89CA64512AF83C1398712FE0 /* PBXTargetDependency */,
-				603E84E6A5F185B540DD5E6C /* PBXTargetDependency */,
-				DEFC6682E29AC81887C9240D /* PBXTargetDependency */,
-				2D0A8B285C970EE1A0797408 /* PBXTargetDependency */,
-			);
-			name = "Pods-EditorDemo";
-			productName = "Pods-EditorDemo";
-			productReference = 68591B6C1D914577D1E61C9C /* libPods-EditorDemo.a */;
-			productType = "com.apple.product-type.library.static";
-		};
-		EA9587BFD26F177B278CAAC5 /* Pods-EditorDemo-WordPress-iOS-Shared-WordPress-iOS-Shared */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 76A7D8816B96D7F1976C7DC1 /* Build configuration list for PBXNativeTarget "Pods-EditorDemo-WordPress-iOS-Shared-WordPress-iOS-Shared" */;
-			buildPhases = (
-				66EA74605EC82D3B3DB421E6 /* Sources */,
-				92144277EB9C9A045A7F1604 /* Frameworks */,
-				3AC1597A9F4C37D927C5F2FB /* Resources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = "Pods-EditorDemo-WordPress-iOS-Shared-WordPress-iOS-Shared";
-			productName = "Pods-EditorDemo-WordPress-iOS-Shared-WordPress-iOS-Shared";
-			productReference = 04FA2B1AA8B4A5E188F32C2F /* WordPress-iOS-Shared.bundle */;
-			productType = "com.apple.product-type.bundle";
-		};
-		EF66BE9BB75DDC0CAF93A2A4 /* Pods-EditorDemo-CocoaLumberjack */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = ED454E094533C7A6DA367B65 /* Build configuration list for PBXNativeTarget "Pods-EditorDemo-CocoaLumberjack" */;
-			buildPhases = (
-				8C81402EAEE11EBEEE7F9F7C /* Sources */,
-				B3D030975FC5C449CBEA58C7 /* Frameworks */,
-				2D4CE65A08656AD9D6803CB9 /* Headers */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = "Pods-EditorDemo-CocoaLumberjack";
-			productName = "Pods-EditorDemo-CocoaLumberjack";
-			productReference = 60160A647A4C6DA0086E5409 /* libPods-EditorDemo-CocoaLumberjack.a */;
-			productType = "com.apple.product-type.library.static";
-		};
-		F735F3AFF58FF4215065D9F1 /* Pods-EditorDemo-WordPress-iOS-Editor */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 643FD4FF3B03953AD73EB522 /* Build configuration list for PBXNativeTarget "Pods-EditorDemo-WordPress-iOS-Editor" */;
-			buildPhases = (
-				BD4904BA043E9C5BE1E582E5 /* Sources */,
-				2CB37AB4936BDE4B19845492 /* Frameworks */,
-				286D083DA6EF41491B199E93 /* Headers */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				EA324BD5AF7D3CCAF49F763F /* PBXTargetDependency */,
-				DF7A99A77FA6B980EFD840D8 /* PBXTargetDependency */,
-				C2A95AD544BE298AD9A391C2 /* PBXTargetDependency */,
-				D8D74719D1D41360920637C1 /* PBXTargetDependency */,
-				9CCC10ED636C614573223436 /* PBXTargetDependency */,
-			);
-			name = "Pods-EditorDemo-WordPress-iOS-Editor";
-			productName = "Pods-EditorDemo-WordPress-iOS-Editor";
-			productReference = 9C5C3884916463A51CB01472 /* libPods-EditorDemo-WordPress-iOS-Editor.a */;
-			productType = "com.apple.product-type.library.static";
-		};
-		F9232E0662913FFA323EABC0 /* Pods-EditorDemoTests-CocoaLumberjack */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = C0650FCD48ADB9419850E17A /* Build configuration list for PBXNativeTarget "Pods-EditorDemoTests-CocoaLumberjack" */;
-			buildPhases = (
-				4CFE46CE00DE2EDCFFCE070A /* Sources */,
-				B9DEE4933931CD491103CD7E /* Frameworks */,
-				314EB762295209DFE595C206 /* Headers */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = "Pods-EditorDemoTests-CocoaLumberjack";
-			productName = "Pods-EditorDemoTests-CocoaLumberjack";
-			productReference = 3ACB4A9A875522B4D969989F /* libPods-EditorDemoTests-CocoaLumberjack.a */;
-			productType = "com.apple.product-type.library.static";
-		};
-		FA5FD4A9C080E0761D062744 /* Pods-EditorDemo-NSObject-SafeExpectations */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 85CC5C109523381F99BC1D37 /* Build configuration list for PBXNativeTarget "Pods-EditorDemo-NSObject-SafeExpectations" */;
-			buildPhases = (
-				F453550C080049904762BB83 /* Sources */,
-				A15019331BF95EEBB2769D8B /* Frameworks */,
-				103AB016E8C5E291D456AE20 /* Headers */,
+				B9C698EDADEC203AA048F15E /* Sources */,
+				D52D42973DB039044D001B4C /* Frameworks */,
+				826A460D3C3AFE0790E7EBC8 /* Headers */,
 			);
 			buildRules = (
 			);
@@ -1733,336 +1549,520 @@
 			);
 			name = "Pods-EditorDemo-NSObject-SafeExpectations";
 			productName = "Pods-EditorDemo-NSObject-SafeExpectations";
-			productReference = 1BB5DD4596CB66A5A3FCB618 /* libPods-EditorDemo-NSObject-SafeExpectations.a */;
+			productReference = 5F5C0A4D9CAF7343AC166722 /* libPods-EditorDemo-NSObject-SafeExpectations.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		14DA1C38BD897A55BC7C57E0 /* Pods-EditorDemo-AFNetworking */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 734B4E40B6BCD8F991F5BDEA /* Build configuration list for PBXNativeTarget "Pods-EditorDemo-AFNetworking" */;
+			buildPhases = (
+				B70177796438F64020AC614D /* Sources */,
+				BA08E6CA93D953DC70610315 /* Frameworks */,
+				BAE30766D4834A8671DDF712 /* Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Pods-EditorDemo-AFNetworking";
+			productName = "Pods-EditorDemo-AFNetworking";
+			productReference = 8C4B50D9E38CB0C5DC4C6E52 /* libPods-EditorDemo-AFNetworking.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		15B586F6C561CD73D6ECF2B9 /* Pods-EditorDemoTests-CocoaLumberjack */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 41B4E40C70D9E1DEA516CCFD /* Build configuration list for PBXNativeTarget "Pods-EditorDemoTests-CocoaLumberjack" */;
+			buildPhases = (
+				28A51691BC43A01CDB7E7BBB /* Sources */,
+				E70DE130E4AFD15B79F03D15 /* Frameworks */,
+				8D6ECB20ED9ED2A2E11AF668 /* Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Pods-EditorDemoTests-CocoaLumberjack";
+			productName = "Pods-EditorDemoTests-CocoaLumberjack";
+			productReference = 3473C21F8B5263449BD7A604 /* libPods-EditorDemoTests-CocoaLumberjack.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		19EFB739DA2174C97CD720E3 /* Pods-EditorDemo */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 761444A6F6B9B3548443F37D /* Build configuration list for PBXNativeTarget "Pods-EditorDemo" */;
+			buildPhases = (
+				710C10188F11165143F0BE1D /* Sources */,
+				C49A9F91366B9003F1D4A458 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				8119A1301C9453018DC48840 /* PBXTargetDependency */,
+				030F15237ECF5FE68F80B0BE /* PBXTargetDependency */,
+				4609386A5EA7F420FF29EA29 /* PBXTargetDependency */,
+				541D2862D77207B3E1DB956A /* PBXTargetDependency */,
+				F9D950120A6C5430D55369FE /* PBXTargetDependency */,
+				FF54FBA39DD5B22410DFC60A /* PBXTargetDependency */,
+				4DD4D1291708DE95601C646C /* PBXTargetDependency */,
+			);
+			name = "Pods-EditorDemo";
+			productName = "Pods-EditorDemo";
+			productReference = 2EE706467EA5CF1BFAD412F6 /* libPods-EditorDemo.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		2DF9E43CC1FCA5E4B490292F /* Pods-EditorDemo-WordPress-iOS-Editor */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 55E3F6CF5B4E038187635D46 /* Build configuration list for PBXNativeTarget "Pods-EditorDemo-WordPress-iOS-Editor" */;
+			buildPhases = (
+				CB71D078FF2C10561DB6819F /* Sources */,
+				170DCF4628520134C7419635 /* Frameworks */,
+				4F876619D34DBFF097AEF336 /* Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				EF9EB0BBBCA111108E1149A5 /* PBXTargetDependency */,
+				BD8DB183F972F99CFE9B7E2D /* PBXTargetDependency */,
+				C1DF5794AD44D4493694D821 /* PBXTargetDependency */,
+				2240B8824D443704D2A2462F /* PBXTargetDependency */,
+				672FBD3E64DF2F4140B1CC67 /* PBXTargetDependency */,
+			);
+			name = "Pods-EditorDemo-WordPress-iOS-Editor";
+			productName = "Pods-EditorDemo-WordPress-iOS-Editor";
+			productReference = 7F04CE6130A817BDD0CD1801 /* libPods-EditorDemo-WordPress-iOS-Editor.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		5E6D10BB217E7B786F5D79C0 /* Pods-EditorDemo-WordPressCom-Analytics-iOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = DA9057388106BD5B20C9A20D /* Build configuration list for PBXNativeTarget "Pods-EditorDemo-WordPressCom-Analytics-iOS" */;
+			buildPhases = (
+				7866DD9C8E7CE08E183BDD15 /* Sources */,
+				E94D99520F114470563B2341 /* Frameworks */,
+				F042C2C07C2733CFC7D13418 /* Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Pods-EditorDemo-WordPressCom-Analytics-iOS";
+			productName = "Pods-EditorDemo-WordPressCom-Analytics-iOS";
+			productReference = 617E743CCBD34CC14239ED5F /* libPods-EditorDemo-WordPressCom-Analytics-iOS.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		8076187268BA2E5AC117B39D /* Pods-EditorDemo-UIAlertView+Blocks */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = B5095AAC24E7598010D749F0 /* Build configuration list for PBXNativeTarget "Pods-EditorDemo-UIAlertView+Blocks" */;
+			buildPhases = (
+				A8E1CC36E3FB0EC5A91D218A /* Sources */,
+				5AB68B682B6BD3C4F124A31C /* Frameworks */,
+				D03BA35AD537BF38B47850F8 /* Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Pods-EditorDemo-UIAlertView+Blocks";
+			productName = "Pods-EditorDemo-UIAlertView+Blocks";
+			productReference = 56611B202B6287B13093772B /* libPods-EditorDemo-UIAlertView+Blocks.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		BEE097ACE07B5200E2FD2A7E /* Pods-EditorDemo-CocoaLumberjack */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 4C75839609962EA00DDD06A0 /* Build configuration list for PBXNativeTarget "Pods-EditorDemo-CocoaLumberjack" */;
+			buildPhases = (
+				72584FF631D2610198852B63 /* Sources */,
+				6913164D3D22553CD7ED509C /* Frameworks */,
+				8A219E9E8091C80683CB4C8D /* Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Pods-EditorDemo-CocoaLumberjack";
+			productName = "Pods-EditorDemo-CocoaLumberjack";
+			productReference = C74F3D313646F7D2310B5F81 /* libPods-EditorDemo-CocoaLumberjack.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		D3A798B2F3EC4A44BB808D7D /* Pods-EditorDemo-WordPress-iOS-Shared */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 66B79A2B70175FEC130294E3 /* Build configuration list for PBXNativeTarget "Pods-EditorDemo-WordPress-iOS-Shared" */;
+			buildPhases = (
+				61789C848905E1B53B95AEC2 /* Sources */,
+				5907DAD2866EE2BD35DE5058 /* Frameworks */,
+				45AF20E6725148998F3BFAE7 /* Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				2977E6A2AD32C1B83D43F0D1 /* PBXTargetDependency */,
+				D496D06657FAFAD806CBFA92 /* PBXTargetDependency */,
+				9B7B5DFC4D3348D5F74938D5 /* PBXTargetDependency */,
+			);
+			name = "Pods-EditorDemo-WordPress-iOS-Shared";
+			productName = "Pods-EditorDemo-WordPress-iOS-Shared";
+			productReference = AB5CEF469BB8828385E8B670 /* libPods-EditorDemo-WordPress-iOS-Shared.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		F943581E7E73994D03920816 /* Pods-EditorDemo-WordPress-iOS-Shared-WordPress-iOS-Shared */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 1A6E4F61DBBF611EFAF46824 /* Build configuration list for PBXNativeTarget "Pods-EditorDemo-WordPress-iOS-Shared-WordPress-iOS-Shared" */;
+			buildPhases = (
+				E57E80A7D9329158A7785F43 /* Sources */,
+				DE6B4E3D759756316FD2C1A9 /* Frameworks */,
+				41822B9771F63861DB7C3115 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Pods-EditorDemo-WordPress-iOS-Shared-WordPress-iOS-Shared";
+			productName = "Pods-EditorDemo-WordPress-iOS-Shared-WordPress-iOS-Shared";
+			productReference = 7BBE9E4C1D09B1398C3EB085 /* WordPress-iOS-Shared.bundle */;
+			productType = "com.apple.product-type.bundle";
+		};
+		FE751089C61438D53C1EBDD1 /* Pods-EditorDemoTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 13F785D3AC37FC4B00C48326 /* Build configuration list for PBXNativeTarget "Pods-EditorDemoTests" */;
+			buildPhases = (
+				38DD3C98E61D1700D2953D9F /* Sources */,
+				B2D11EBA9A08EEE8D8945D7E /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				5CC8504AE1FB7820F1179909 /* PBXTargetDependency */,
+			);
+			name = "Pods-EditorDemoTests";
+			productName = "Pods-EditorDemoTests";
+			productReference = 94424D69775A77CFB3BD44C9 /* libPods-EditorDemoTests.a */;
 			productType = "com.apple.product-type.library.static";
 		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
-		8271F7CE20E8F531623E8A97 /* Project object */ = {
+		F0816A4D6FC502289658307E /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
 				LastUpgradeCheck = 0640;
 			};
-			buildConfigurationList = E37D513A08AC2C2A32DF2A5F /* Build configuration list for PBXProject "Pods" */;
+			buildConfigurationList = B3623581EEB6F962C6577689 /* Build configuration list for PBXProject "Pods" */;
 			compatibilityVersion = "Xcode 3.2";
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
 			);
-			mainGroup = 4AD30E23BC40842A477A945A;
-			productRefGroup = BCFBD51D6D8D3153A10B4B79 /* Products */;
+			mainGroup = 4AA66900CC2026B2B9E4D8BA;
+			productRefGroup = 0BBD3BA262DA2D6BC2D9C0E9 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				CBA62BA361B3BA3988412C3A /* Pods-EditorDemo */,
-				BEE2D6A907D7AB7A9244F7C1 /* Pods-EditorDemo-AFNetworking */,
-				EF66BE9BB75DDC0CAF93A2A4 /* Pods-EditorDemo-CocoaLumberjack */,
-				FA5FD4A9C080E0761D062744 /* Pods-EditorDemo-NSObject-SafeExpectations */,
-				684969EABA68BEADF10760C6 /* Pods-EditorDemo-UIAlertView+Blocks */,
-				F735F3AFF58FF4215065D9F1 /* Pods-EditorDemo-WordPress-iOS-Editor */,
-				5B5431C7C77BA40377BC1687 /* Pods-EditorDemo-WordPress-iOS-Shared */,
-				EA9587BFD26F177B278CAAC5 /* Pods-EditorDemo-WordPress-iOS-Shared-WordPress-iOS-Shared */,
-				7F986800EA7C868765DE35F0 /* Pods-EditorDemo-WordPressCom-Analytics-iOS */,
-				8370BACC5BF439087B250486 /* Pods-EditorDemoTests */,
-				F9232E0662913FFA323EABC0 /* Pods-EditorDemoTests-CocoaLumberjack */,
+				19EFB739DA2174C97CD720E3 /* Pods-EditorDemo */,
+				14DA1C38BD897A55BC7C57E0 /* Pods-EditorDemo-AFNetworking */,
+				BEE097ACE07B5200E2FD2A7E /* Pods-EditorDemo-CocoaLumberjack */,
+				0393028516D354A9A4D3EF99 /* Pods-EditorDemo-NSObject-SafeExpectations */,
+				8076187268BA2E5AC117B39D /* Pods-EditorDemo-UIAlertView+Blocks */,
+				2DF9E43CC1FCA5E4B490292F /* Pods-EditorDemo-WordPress-iOS-Editor */,
+				D3A798B2F3EC4A44BB808D7D /* Pods-EditorDemo-WordPress-iOS-Shared */,
+				F943581E7E73994D03920816 /* Pods-EditorDemo-WordPress-iOS-Shared-WordPress-iOS-Shared */,
+				5E6D10BB217E7B786F5D79C0 /* Pods-EditorDemo-WordPressCom-Analytics-iOS */,
+				FE751089C61438D53C1EBDD1 /* Pods-EditorDemoTests */,
+				15B586F6C561CD73D6ECF2B9 /* Pods-EditorDemoTests-CocoaLumberjack */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
-		3AC1597A9F4C37D927C5F2FB /* Resources */ = {
+		41822B9771F63861DB7C3115 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				D5F3C06206C1C8D08F321A8C /* Merriweather-Bold.ttf in Resources */,
-				A0D13B590FAE2303E26BF2A5 /* Merriweather-BoldItalic.otf in Resources */,
-				32BD744D61A0B10D85546E85 /* Merriweather-Italic.otf in Resources */,
-				032D2E088521A72F0735E2CC /* Merriweather-Light.ttf in Resources */,
-				708744E85D863852339B4E0B /* Merriweather-LightItalic.otf in Resources */,
-				C624F0F06734AE0FA3B8E21E /* Merriweather-Regular.ttf in Resources */,
-				8D8A4825B184DBB76F2B95E2 /* OpenSans-Bold.ttf in Resources */,
-				DBDF664E8B1DF327EC16D6C2 /* OpenSans-BoldItalic.ttf in Resources */,
-				9193432B22F64F243D92D761 /* OpenSans-Italic.ttf in Resources */,
-				DBA6CB07F9CF64491D9F4F3F /* OpenSans-Light.ttf in Resources */,
-				DC08879134FF6D09D48B84BA /* OpenSans-LightItalic.ttf in Resources */,
-				A484D2247DBCD95B894C3ADA /* OpenSans-Regular.ttf in Resources */,
-				E4A4432F93C38D9508C32E2E /* OpenSans-Semibold.ttf in Resources */,
-				6BFAE6772D14F733C989F1E0 /* OpenSans-SemiboldItalic.ttf in Resources */,
+				FF7402E0AA556400A209D3B0 /* Merriweather-Bold.ttf in Resources */,
+				020EC4F208ACE02A1A56701D /* Merriweather-BoldItalic.otf in Resources */,
+				AB7F9ADF6247BFFF16A7C969 /* Merriweather-Italic.otf in Resources */,
+				B738C45B49188DA699F0677E /* Merriweather-Light.ttf in Resources */,
+				F69056803DF594FB65E4A179 /* Merriweather-LightItalic.otf in Resources */,
+				0F70F37CA698BE7892F92DF1 /* Merriweather-Regular.ttf in Resources */,
+				43B35A5FC4CE86AFF862D8CA /* OpenSans-Bold.ttf in Resources */,
+				AB9A16BD56C0F4E937442A50 /* OpenSans-BoldItalic.ttf in Resources */,
+				ADC0448276C8890FBB316DAF /* OpenSans-Italic.ttf in Resources */,
+				E6EB119A582FDF2C8991D340 /* OpenSans-Light.ttf in Resources */,
+				4C7BD9820947738968D2A0A0 /* OpenSans-LightItalic.ttf in Resources */,
+				E3FBB9BA5560FC15173A572F /* OpenSans-Regular.ttf in Resources */,
+				E26769B0238C6187391550B6 /* OpenSans-Semibold.ttf in Resources */,
+				5D1472B85D5FA71B9F9E5003 /* OpenSans-SemiboldItalic.ttf in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
-		14DB1F0873D20DE635DE81B2 /* Sources */ = {
+		28A51691BC43A01CDB7E7BBB /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				FCAA73E57BB49D2B7665D4EF /* Pods-EditorDemo-dummy.m in Sources */,
+				CB86C5380139BD15B2D4D23B /* DDASLLogCapture.m in Sources */,
+				AC0FCE9CEF54F774867E8968 /* DDASLLogger.m in Sources */,
+				04602B3981D5E6CE7F7E5A56 /* DDAbstractDatabaseLogger.m in Sources */,
+				B4FDEB5CE7A422109124CAF4 /* DDContextFilterLogFormatter.m in Sources */,
+				63BF1CD1F1C1AF2014347D50 /* DDDispatchQueueLogFormatter.m in Sources */,
+				6C5C08287C868DEB4E2932D9 /* DDFileLogger.m in Sources */,
+				1FD20E00092B54DCF96DB9A4 /* DDLog.m in Sources */,
+				6B401B6756884BB3678D8657 /* DDMultiFormatter.m in Sources */,
+				295815DC817F873B9B775EBD /* DDTTYLogger.m in Sources */,
+				771B76954B55F7C8431FFEF3 /* Pods-EditorDemoTests-CocoaLumberjack-dummy.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		37DA34DD24DA2A99E6F693D3 /* Sources */ = {
+		38DD3C98E61D1700D2953D9F /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				116BB4108DEA8D3D4CE63FDA /* Pods-EditorDemo-UIAlertView+Blocks-dummy.m in Sources */,
-				F40487AA465CA6A70E7E4277 /* UIAlertView+Blocks.m in Sources */,
+				5FB3010F22AEA24CA3669054 /* Pods-EditorDemoTests-dummy.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		4CFE46CE00DE2EDCFFCE070A /* Sources */ = {
+		61789C848905E1B53B95AEC2 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				9A5297153F39809788FD4708 /* DDASLLogCapture.m in Sources */,
-				8572D7994C93A2F7C6084087 /* DDASLLogger.m in Sources */,
-				59E50E935422D77016F3D309 /* DDAbstractDatabaseLogger.m in Sources */,
-				4B0DB6F7D025A5066352BAF6 /* DDContextFilterLogFormatter.m in Sources */,
-				802E41D76C3B69CC11F0CD2F /* DDDispatchQueueLogFormatter.m in Sources */,
-				C490CEABA4A3E288169ED01F /* DDFileLogger.m in Sources */,
-				D86632C887234BE2C4DA70CD /* DDLog.m in Sources */,
-				CB7B6FAFE41001E0B3A26360 /* DDMultiFormatter.m in Sources */,
-				1DE9A02057E3C3587D4D973A /* DDTTYLogger.m in Sources */,
-				BE4C2F69103020B047D2AF1F /* Pods-EditorDemoTests-CocoaLumberjack-dummy.m in Sources */,
+				4A5B47755A7CB798A393153D /* NSString+Util.m in Sources */,
+				67C20A77404F2021E7DDB36B /* NSString+XMLExtensions.m in Sources */,
+				B40E391CF2EE1659974E1B5C /* Pods-EditorDemo-WordPress-iOS-Shared-dummy.m in Sources */,
+				F73A073A4D07BDF43E4026D9 /* UIColor+Helpers.m in Sources */,
+				9ED2C863083B9955875ABFA5 /* UIImage+Util.m in Sources */,
+				02612EC75199A0BD8B6C3128 /* UITableViewTextFieldCell.m in Sources */,
+				1702D9526E67742556A0309C /* WPAnimatedImageResponseSerializer.m in Sources */,
+				9ED5E2087D695FD07562A2AB /* WPDeviceIdentification.m in Sources */,
+				E5E8212F6255A8FB06902F8A /* WPFontManager.m in Sources */,
+				4AEEC8B0999760BE1EEEA55C /* WPImageSource.m in Sources */,
+				D498B7A31767B32911C03C2F /* WPNUXUtility.m in Sources */,
+				D62092865CBEA6891A04D871 /* WPNoResultsView.m in Sources */,
+				4F195D16BEDDF05548D3C8EE /* WPStyleGuide.m in Sources */,
+				EAC0B7519D7B44AA998F14CC /* WPTableViewCell.m in Sources */,
+				601B44FB8FF5B3073C52C654 /* WPTableViewSectionFooterView.m in Sources */,
+				96A40BCF7845F397F3ADE371 /* WPTableViewSectionHeaderView.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		5281504B79E68BFF8605F21E /* Sources */ = {
+		710C10188F11165143F0BE1D /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				0672590DEED801308306313F /* NSString+Util.m in Sources */,
-				FD8946BEFE65628074965029 /* NSString+XMLExtensions.m in Sources */,
-				FDE18071A718A7FA522EF298 /* Pods-EditorDemo-WordPress-iOS-Shared-dummy.m in Sources */,
-				E118BA870BE5067A4C4E1248 /* UIColor+Helpers.m in Sources */,
-				BF759388B75EE19051D13DFC /* UIImage+Util.m in Sources */,
-				1C9ADAD2C4C9DFD71B61545F /* UITableViewTextFieldCell.m in Sources */,
-				3DCC994222F09A501755A611 /* WPAnimatedImageResponseSerializer.m in Sources */,
-				1ECDFF15364658E3B24A8082 /* WPDeviceIdentification.m in Sources */,
-				0AE640F07A3A08E8DEDBF6FE /* WPFontManager.m in Sources */,
-				99339BF95DF0EED4E7CD6ECC /* WPImageSource.m in Sources */,
-				614D39AEC68B48C3526B4B08 /* WPNUXUtility.m in Sources */,
-				887C70DA5DB9D0011BCB3364 /* WPNoResultsView.m in Sources */,
-				90490ADBB98325B56BF50723 /* WPStyleGuide.m in Sources */,
-				67A1C7836386B064584FC260 /* WPTableViewCell.m in Sources */,
-				4E62DCC1334267D8744BF900 /* WPTableViewSectionFooterView.m in Sources */,
-				CB6DF23BB60BFD24507FCDF4 /* WPTableViewSectionHeaderView.m in Sources */,
+				CCD33E7253FA7F2BC6878677 /* Pods-EditorDemo-dummy.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		66EA74605EC82D3B3DB421E6 /* Sources */ = {
+		72584FF631D2610198852B63 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				2E98DC2BE05BEC96145E716A /* DDASLLogCapture.m in Sources */,
+				9798C038DC6E903CE3314867 /* DDASLLogger.m in Sources */,
+				D6365E613803E1DFEDC0D92F /* DDAbstractDatabaseLogger.m in Sources */,
+				35DB7B3006D92E5ECA2AF438 /* DDContextFilterLogFormatter.m in Sources */,
+				0C2C861B920A7ADA284E29FD /* DDDispatchQueueLogFormatter.m in Sources */,
+				EE89C9B73413E7BF784DEC81 /* DDFileLogger.m in Sources */,
+				26C7CD786E631628F76A32BC /* DDLog.m in Sources */,
+				C094E675878FBCED2F6A7076 /* DDMultiFormatter.m in Sources */,
+				C994C49E96A3B63C3FE1B026 /* DDTTYLogger.m in Sources */,
+				72058F94CD93567431869743 /* Pods-EditorDemo-CocoaLumberjack-dummy.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		8C81402EAEE11EBEEE7F9F7C /* Sources */ = {
+		7866DD9C8E7CE08E183BDD15 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				08EF81487A47DB5758DCD18D /* DDASLLogCapture.m in Sources */,
-				99ED38D1D677E229CFD167F3 /* DDASLLogger.m in Sources */,
-				539541642E02EEF5C359ED7C /* DDAbstractDatabaseLogger.m in Sources */,
-				40953DC82F87E7D16F7A72B5 /* DDContextFilterLogFormatter.m in Sources */,
-				58F48F2CBBAB6F1DFF84DD00 /* DDDispatchQueueLogFormatter.m in Sources */,
-				528DA4EA1E7A88ED2192F6B7 /* DDFileLogger.m in Sources */,
-				FB8C14D68B4A80775773DC59 /* DDLog.m in Sources */,
-				81A78326C944FF2A248EB535 /* DDMultiFormatter.m in Sources */,
-				66F8AD65B213D1C70FAA0F97 /* DDTTYLogger.m in Sources */,
-				0855F7C21B79C5D5F9A540F0 /* Pods-EditorDemo-CocoaLumberjack-dummy.m in Sources */,
+				72D231C1EBEEC3937BBD34FE /* Pods-EditorDemo-WordPressCom-Analytics-iOS-dummy.m in Sources */,
+				0B084D02CC892F604F635E57 /* WPAnalytics.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		8D9EA44DAD922CAA9E2E18B7 /* Sources */ = {
+		A8E1CC36E3FB0EC5A91D218A /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				1CB9C776BB1B9DF6C4FF6C13 /* Pods-EditorDemo-WordPressCom-Analytics-iOS-dummy.m in Sources */,
-				FFDEB51E3C46E9F4FF8D5FF9 /* WPAnalytics.m in Sources */,
+				3E3F64C4F7C7ECA9CE6BFE23 /* Pods-EditorDemo-UIAlertView+Blocks-dummy.m in Sources */,
+				682E24244A4D196F54425E8F /* UIAlertView+Blocks.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		ABD661EA8BBB2D9EA712B4F6 /* Sources */ = {
+		B70177796438F64020AC614D /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				61C97315AAD2F71789A4C2AA /* Pods-EditorDemoTests-dummy.m in Sources */,
+				2DA1701E1374F4490EA6E4D9 /* AFHTTPRequestOperation.m in Sources */,
+				D93867AE3D96C055CBEC659A /* AFHTTPRequestOperationManager.m in Sources */,
+				9B3D4B334A933570EDC60F93 /* AFHTTPSessionManager.m in Sources */,
+				48379B04A0BBC6AFC7A2A791 /* AFNetworkActivityIndicatorManager.m in Sources */,
+				FAC5096955D6B4D1DDD7777B /* AFNetworkReachabilityManager.m in Sources */,
+				E04A01ECC56C9FFC260948C5 /* AFSecurityPolicy.m in Sources */,
+				9DD2ADC7E5F0F64E2382787C /* AFURLConnectionOperation.m in Sources */,
+				24C831C00EDE4DA26BF1B4E1 /* AFURLRequestSerialization.m in Sources */,
+				67F2D02E6FC3F13CC722096C /* AFURLResponseSerialization.m in Sources */,
+				BCAD3D083F7064A5BDC49F30 /* AFURLSessionManager.m in Sources */,
+				EE8D321D67823174062BF49C /* Pods-EditorDemo-AFNetworking-dummy.m in Sources */,
+				7703B851D7D705B9B4787D67 /* UIActivityIndicatorView+AFNetworking.m in Sources */,
+				2C9AED1E162E565FACB9A6A9 /* UIAlertView+AFNetworking.m in Sources */,
+				D4569EEA542A5AEE4C517DE1 /* UIButton+AFNetworking.m in Sources */,
+				37B9C1E91E2ABA7305271950 /* UIImageView+AFNetworking.m in Sources */,
+				117434C0D7D67DB426CFFCCD /* UIProgressView+AFNetworking.m in Sources */,
+				EB5E82185FDED2D30B1E0502 /* UIRefreshControl+AFNetworking.m in Sources */,
+				0BCC9303774F5B3E5E86C7E8 /* UIWebView+AFNetworking.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		AE9AFD6513D789D64408716A /* Sources */ = {
+		B9C698EDADEC203AA048F15E /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				6816C1EF210499DD5D3D88B2 /* AFHTTPRequestOperation.m in Sources */,
-				5D9B302E870953CBD6CAC2C7 /* AFHTTPRequestOperationManager.m in Sources */,
-				1F2CEAFE3390A89C60266DBD /* AFHTTPSessionManager.m in Sources */,
-				F83199F7211C6267C36910F5 /* AFNetworkActivityIndicatorManager.m in Sources */,
-				C67E431E9D6A0699BABB37B7 /* AFNetworkReachabilityManager.m in Sources */,
-				2EBAF12F3E723F4BA61E5287 /* AFSecurityPolicy.m in Sources */,
-				9A975DEB34852A685EB02A48 /* AFURLConnectionOperation.m in Sources */,
-				94BA1121967D85D72E70E7A4 /* AFURLRequestSerialization.m in Sources */,
-				031BF23E2C0CF4AE3999738C /* AFURLResponseSerialization.m in Sources */,
-				63E28CC2686764246641D7A2 /* AFURLSessionManager.m in Sources */,
-				FDD54CD64EE9508D3A210AB3 /* Pods-EditorDemo-AFNetworking-dummy.m in Sources */,
-				13DD29457E8DE2A2908C0A72 /* UIActivityIndicatorView+AFNetworking.m in Sources */,
-				73A22ABE684857E2A567FC6E /* UIAlertView+AFNetworking.m in Sources */,
-				6E5200EF3D9D8A58CF6A2345 /* UIButton+AFNetworking.m in Sources */,
-				98A27AC7FBA753CBC927C99F /* UIImageView+AFNetworking.m in Sources */,
-				01B4626822D05E3B273321C4 /* UIProgressView+AFNetworking.m in Sources */,
-				19E2E264A61E6CF3FF0153E7 /* UIRefreshControl+AFNetworking.m in Sources */,
-				DD78E2DAA828A45F29D86603 /* UIWebView+AFNetworking.m in Sources */,
+				20136684E7E621794A2A27CB /* NSDictionary+SafeExpectations.m in Sources */,
+				835CFF91BA2C62DD4A6EB222 /* Pods-EditorDemo-NSObject-SafeExpectations-dummy.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		BD4904BA043E9C5BE1E582E5 /* Sources */ = {
+		CB71D078FF2C10561DB6819F /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				9C4262218C1581A2254A983A /* CYRLayoutManager.m in Sources */,
-				B5F4FC87901E5EA1350AD590 /* CYRTextStorage.m in Sources */,
-				FE5C92CE7AF11FB4E90AC624 /* CYRTextView.m in Sources */,
-				B2F1C0DB2FB0673C695B20E8 /* CYRToken.m in Sources */,
-				053980AF17F83BC2CE4078A1 /* HRBrightnessCursor.m in Sources */,
-				6FA4467E1A9CFB46E0215CF3 /* HRCgUtil.m in Sources */,
-				089901F315CD1C54C940C846 /* HRColorCursor.m in Sources */,
-				D49509718A9942A386E84882 /* HRColorPickerView.m in Sources */,
-				1EC80F743F1101E40461F989 /* HRColorPickerViewController.m in Sources */,
-				C6EB57E0CDF62432156B4E60 /* HRColorUtil.m in Sources */,
-				0DAD4E0A7CDE786B61E0C44B /* Pods-EditorDemo-WordPress-iOS-Editor-dummy.m in Sources */,
-				36F753DF5C5D5EEEFA27C993 /* UIWebView+GUIFixes.m in Sources */,
-				A94150515F6697D6760627EE /* WPEditorField.m in Sources */,
-				42DAFC39BD9D3B670F8C0F13 /* WPEditorLoggingConfiguration.m in Sources */,
-				089EA3D31D9BDC68F2E9DA49 /* WPEditorToolbarButton.m in Sources */,
-				1D83171BE4CD7ED42BFD2A7D /* WPEditorToolbarView.m in Sources */,
-				0D8A142AF6030770B9B21D9B /* WPEditorView.m in Sources */,
-				1E25D29A9939FA3B713E03F1 /* WPEditorViewController.m in Sources */,
-				682CA74726C04205C0551787 /* WPImageMeta.m in Sources */,
-				A258F59DA8E45E0B6969ADB2 /* WPLegacyEditorViewController.m in Sources */,
-				D0B79DEB6EC5E0E2BB9DF23A /* WPLegacyKeyboardToolbarBase.m in Sources */,
-				8602F22FA0E18A5444960A68 /* WPLegacyKeyboardToolbarButtonItem.m in Sources */,
-				F57DD9B800E1DADC70DE5968 /* WPLegacyKeyboardToolbarDone.m in Sources */,
-				F9E378B8916903EA9EB19BB5 /* ZSSBarButtonItem.m in Sources */,
-				C6682B4A07C0D42523566737 /* ZSSTextView.m in Sources */,
+				738F097815FD31FB5AC4BAEB /* CYRLayoutManager.m in Sources */,
+				E11133045C1673D188391027 /* CYRTextStorage.m in Sources */,
+				37F845EB1643CAA07B3DEEC3 /* CYRTextView.m in Sources */,
+				94DEF0859EF39C1B2EA934A8 /* CYRToken.m in Sources */,
+				E14093CAE16763D00984E737 /* HRBrightnessCursor.m in Sources */,
+				E57E5C98ACF180B75B54AE74 /* HRCgUtil.m in Sources */,
+				7EC36CFB9EE037365326488A /* HRColorCursor.m in Sources */,
+				7ED8086034BA76D220561EAF /* HRColorPickerView.m in Sources */,
+				574E72B245124E1F6D39DD9E /* HRColorPickerViewController.m in Sources */,
+				66B8653EF63CA90D21A2A380 /* HRColorUtil.m in Sources */,
+				6A3196A1CD5D0C95B6031AEB /* Pods-EditorDemo-WordPress-iOS-Editor-dummy.m in Sources */,
+				A794B130912D80392430668C /* UIWebView+GUIFixes.m in Sources */,
+				11A94BCCBB13A7303267378D /* WPEditorField.m in Sources */,
+				173A733C2FE16FDBB9A38ABA /* WPEditorLoggingConfiguration.m in Sources */,
+				53FC0F35997842C8E018848F /* WPEditorToolbarButton.m in Sources */,
+				409DD2DF1792D67A24582A9A /* WPEditorToolbarView.m in Sources */,
+				FC6EB64BC6B9D6DE07721D15 /* WPEditorView.m in Sources */,
+				1E27E19030289822CBF33FC8 /* WPEditorViewController.m in Sources */,
+				0DB8E628A62D32050167ACE2 /* WPImageMeta.m in Sources */,
+				C392B2E9DFB97D3E513FA584 /* WPLegacyEditorViewController.m in Sources */,
+				D0D3428A3A13E91DCB25C4E1 /* WPLegacyKeyboardToolbarBase.m in Sources */,
+				5752114E2C2BBDEFD164D84A /* WPLegacyKeyboardToolbarButtonItem.m in Sources */,
+				6269D7331C3895524227D81E /* WPLegacyKeyboardToolbarDone.m in Sources */,
+				ABBF193788F5B8D1EB389F3A /* ZSSBarButtonItem.m in Sources */,
+				89499C7156D8394491DD9026 /* ZSSTextView.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		F453550C080049904762BB83 /* Sources */ = {
+		E57E80A7D9329158A7785F43 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				9DF55F067502C0A89D23ED4B /* NSDictionary+SafeExpectations.m in Sources */,
-				392E346EFB7317E6BB72DB12 /* Pods-EditorDemo-NSObject-SafeExpectations-dummy.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		2D0A8B285C970EE1A0797408 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "Pods-EditorDemo-WordPressCom-Analytics-iOS";
-			target = 7F986800EA7C868765DE35F0 /* Pods-EditorDemo-WordPressCom-Analytics-iOS */;
-			targetProxy = A70F164E374D980AE4E04010 /* PBXContainerItemProxy */;
-		};
-		603E84E6A5F185B540DD5E6C /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "Pods-EditorDemo-WordPress-iOS-Editor";
-			target = F735F3AFF58FF4215065D9F1 /* Pods-EditorDemo-WordPress-iOS-Editor */;
-			targetProxy = 84EDBCD06B0D00DD3210EBBD /* PBXContainerItemProxy */;
-		};
-		6F31C7ED476979DDECF77187 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "Pods-EditorDemo-AFNetworking";
-			target = BEE2D6A907D7AB7A9244F7C1 /* Pods-EditorDemo-AFNetworking */;
-			targetProxy = 053B8D1CD06E60242068CC6A /* PBXContainerItemProxy */;
-		};
-		89CA64512AF83C1398712FE0 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "Pods-EditorDemo-UIAlertView+Blocks";
-			target = 684969EABA68BEADF10760C6 /* Pods-EditorDemo-UIAlertView+Blocks */;
-			targetProxy = CBB2E5A4E9C59F02C6090D14 /* PBXContainerItemProxy */;
-		};
-		970E8B8E0525B61F7BEC62C8 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "Pods-EditorDemo-WordPress-iOS-Shared-WordPress-iOS-Shared";
-			target = EA9587BFD26F177B278CAAC5 /* Pods-EditorDemo-WordPress-iOS-Shared-WordPress-iOS-Shared */;
-			targetProxy = C137F8925FAE86F0A5B5FC4A /* PBXContainerItemProxy */;
-		};
-		989988A536DCC5BAC0563CB3 /* PBXTargetDependency */ = {
+		030F15237ECF5FE68F80B0BE /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = "Pods-EditorDemo-CocoaLumberjack";
-			target = EF66BE9BB75DDC0CAF93A2A4 /* Pods-EditorDemo-CocoaLumberjack */;
-			targetProxy = 63764D97FD738E04AFC2D702 /* PBXContainerItemProxy */;
+			target = BEE097ACE07B5200E2FD2A7E /* Pods-EditorDemo-CocoaLumberjack */;
+			targetProxy = 915781B0DE1C151111238425 /* PBXContainerItemProxy */;
 		};
-		9CCC10ED636C614573223436 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "Pods-EditorDemo-WordPressCom-Analytics-iOS";
-			target = 7F986800EA7C868765DE35F0 /* Pods-EditorDemo-WordPressCom-Analytics-iOS */;
-			targetProxy = A64853A751234EEB2C81D70B /* PBXContainerItemProxy */;
-		};
-		A6E8D0425A39945A78A18C94 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "Pods-EditorDemo-AFNetworking";
-			target = BEE2D6A907D7AB7A9244F7C1 /* Pods-EditorDemo-AFNetworking */;
-			targetProxy = DBFED12E6E17D5DAC10C6C62 /* PBXContainerItemProxy */;
-		};
-		BD004CBB9B9896E1E0C1EA9D /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "Pods-EditorDemo-NSObject-SafeExpectations";
-			target = FA5FD4A9C080E0761D062744 /* Pods-EditorDemo-NSObject-SafeExpectations */;
-			targetProxy = 5D11850C6C3489B42A6BF181 /* PBXContainerItemProxy */;
-		};
-		C2A95AD544BE298AD9A391C2 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "Pods-EditorDemo-UIAlertView+Blocks";
-			target = 684969EABA68BEADF10760C6 /* Pods-EditorDemo-UIAlertView+Blocks */;
-			targetProxy = 718AA23BC316C48D8AAA40CE /* PBXContainerItemProxy */;
-		};
-		D8D74719D1D41360920637C1 /* PBXTargetDependency */ = {
+		2240B8824D443704D2A2462F /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = "Pods-EditorDemo-WordPress-iOS-Shared";
-			target = 5B5431C7C77BA40377BC1687 /* Pods-EditorDemo-WordPress-iOS-Shared */;
-			targetProxy = 4A57ECF9385D63F93D59F1DE /* PBXContainerItemProxy */;
+			target = D3A798B2F3EC4A44BB808D7D /* Pods-EditorDemo-WordPress-iOS-Shared */;
+			targetProxy = 347DFA422F3B9A90E0FE68C2 /* PBXContainerItemProxy */;
 		};
-		DDB40B615022A8DAEB700EB9 /* PBXTargetDependency */ = {
+		2977E6A2AD32C1B83D43F0D1 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Pods-EditorDemo-AFNetworking";
+			target = 14DA1C38BD897A55BC7C57E0 /* Pods-EditorDemo-AFNetworking */;
+			targetProxy = 7289541ACD672ED649281BA3 /* PBXContainerItemProxy */;
+		};
+		4609386A5EA7F420FF29EA29 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Pods-EditorDemo-NSObject-SafeExpectations";
+			target = 0393028516D354A9A4D3EF99 /* Pods-EditorDemo-NSObject-SafeExpectations */;
+			targetProxy = 6F45910311E7BA4B869E3C21 /* PBXContainerItemProxy */;
+		};
+		4DD4D1291708DE95601C646C /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Pods-EditorDemo-WordPressCom-Analytics-iOS";
+			target = 5E6D10BB217E7B786F5D79C0 /* Pods-EditorDemo-WordPressCom-Analytics-iOS */;
+			targetProxy = 3145E228AD71D0966CA32BCD /* PBXContainerItemProxy */;
+		};
+		541D2862D77207B3E1DB956A /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Pods-EditorDemo-UIAlertView+Blocks";
+			target = 8076187268BA2E5AC117B39D /* Pods-EditorDemo-UIAlertView+Blocks */;
+			targetProxy = FA6A4B32327C8DA6C1A3F33F /* PBXContainerItemProxy */;
+		};
+		5CC8504AE1FB7820F1179909 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = "Pods-EditorDemoTests-CocoaLumberjack";
-			target = F9232E0662913FFA323EABC0 /* Pods-EditorDemoTests-CocoaLumberjack */;
-			targetProxy = A2E098CB2A146E80D28F23AE /* PBXContainerItemProxy */;
+			target = 15B586F6C561CD73D6ECF2B9 /* Pods-EditorDemoTests-CocoaLumberjack */;
+			targetProxy = 2888BB7333BE006076904727 /* PBXContainerItemProxy */;
 		};
-		DEFC6682E29AC81887C9240D /* PBXTargetDependency */ = {
+		672FBD3E64DF2F4140B1CC67 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			name = "Pods-EditorDemo-WordPress-iOS-Shared";
-			target = 5B5431C7C77BA40377BC1687 /* Pods-EditorDemo-WordPress-iOS-Shared */;
-			targetProxy = E83E4AB92E6CCE8CC3ECF25E /* PBXContainerItemProxy */;
+			name = "Pods-EditorDemo-WordPressCom-Analytics-iOS";
+			target = 5E6D10BB217E7B786F5D79C0 /* Pods-EditorDemo-WordPressCom-Analytics-iOS */;
+			targetProxy = 6A8D9861EA93060C17ADB3D2 /* PBXContainerItemProxy */;
 		};
-		DF7A99A77FA6B980EFD840D8 /* PBXTargetDependency */ = {
+		8119A1301C9453018DC48840 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Pods-EditorDemo-AFNetworking";
+			target = 14DA1C38BD897A55BC7C57E0 /* Pods-EditorDemo-AFNetworking */;
+			targetProxy = 6B331479DABD27D68472575B /* PBXContainerItemProxy */;
+		};
+		9B7B5DFC4D3348D5F74938D5 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Pods-EditorDemo-WordPress-iOS-Shared-WordPress-iOS-Shared";
+			target = F943581E7E73994D03920816 /* Pods-EditorDemo-WordPress-iOS-Shared-WordPress-iOS-Shared */;
+			targetProxy = 988616CC35C8E4BAC72ADC00 /* PBXContainerItemProxy */;
+		};
+		BD8DB183F972F99CFE9B7E2D /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = "Pods-EditorDemo-NSObject-SafeExpectations";
-			target = FA5FD4A9C080E0761D062744 /* Pods-EditorDemo-NSObject-SafeExpectations */;
-			targetProxy = 6C91A6744405BA24C0BF4C5F /* PBXContainerItemProxy */;
+			target = 0393028516D354A9A4D3EF99 /* Pods-EditorDemo-NSObject-SafeExpectations */;
+			targetProxy = 20EA7ED7C6B5706503E2F326 /* PBXContainerItemProxy */;
 		};
-		E78E1DC72E1412A1C0609ECB /* PBXTargetDependency */ = {
+		C1DF5794AD44D4493694D821 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Pods-EditorDemo-UIAlertView+Blocks";
+			target = 8076187268BA2E5AC117B39D /* Pods-EditorDemo-UIAlertView+Blocks */;
+			targetProxy = 048D67368EA22641BE75D0E1 /* PBXContainerItemProxy */;
+		};
+		D496D06657FAFAD806CBFA92 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = "Pods-EditorDemo-CocoaLumberjack";
-			target = EF66BE9BB75DDC0CAF93A2A4 /* Pods-EditorDemo-CocoaLumberjack */;
-			targetProxy = 7A1FED650D23667E449449B7 /* PBXContainerItemProxy */;
+			target = BEE097ACE07B5200E2FD2A7E /* Pods-EditorDemo-CocoaLumberjack */;
+			targetProxy = D81BB86992BEF6A4742C4C0E /* PBXContainerItemProxy */;
 		};
-		EA324BD5AF7D3CCAF49F763F /* PBXTargetDependency */ = {
+		EF9EB0BBBCA111108E1149A5 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = "Pods-EditorDemo-CocoaLumberjack";
-			target = EF66BE9BB75DDC0CAF93A2A4 /* Pods-EditorDemo-CocoaLumberjack */;
-			targetProxy = 81F7F26651C0D81E2B15B038 /* PBXContainerItemProxy */;
+			target = BEE097ACE07B5200E2FD2A7E /* Pods-EditorDemo-CocoaLumberjack */;
+			targetProxy = D59C9306379C634A6B929CDB /* PBXContainerItemProxy */;
+		};
+		F9D950120A6C5430D55369FE /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Pods-EditorDemo-WordPress-iOS-Editor";
+			target = 2DF9E43CC1FCA5E4B490292F /* Pods-EditorDemo-WordPress-iOS-Editor */;
+			targetProxy = 0DE906DA61146424585F8EB6 /* PBXContainerItemProxy */;
+		};
+		FF54FBA39DD5B22410DFC60A /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Pods-EditorDemo-WordPress-iOS-Shared";
+			target = D3A798B2F3EC4A44BB808D7D /* Pods-EditorDemo-WordPress-iOS-Shared */;
+			targetProxy = 099571317EB7E73D1DA765FE /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
-		060DE70B54F89D1C6F6758FE /* Debug */ = {
+		006357B7652DB0D04133246E /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -2101,37 +2101,9 @@
 			};
 			name = Debug;
 		};
-		11797432C89843D2520C0FC0 /* Release */ = {
+		021CD7737D4BDC9E38C06713 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = CED050E53B65F55252827DB2 /* Pods-EditorDemo-WordPress-iOS-Shared-Private.xcconfig */;
-			buildSettings = {
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				PRODUCT_NAME = "WordPress-iOS-Shared";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				WRAPPER_EXTENSION = bundle;
-			};
-			name = Release;
-		};
-		127E4421CCC5868AAD10FD74 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 95625436A073EB8182AEF56A /* Pods-EditorDemo-CocoaLumberjack-Private.xcconfig */;
-			buildSettings = {
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/Pods-EditorDemo-CocoaLumberjack/Pods-EditorDemo-CocoaLumberjack-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
-				MTL_ENABLE_DEBUG_INFO = NO;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-			};
-			name = Release;
-		};
-		3A257DE87A6BA1416A591D26 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = C74D92E6172B18645410B660 /* Pods-EditorDemo-AFNetworking-Private.xcconfig */;
+			baseConfigurationReference = F2C07F7D3B78CFCEAC52945D /* Pods-EditorDemo-AFNetworking-Private.xcconfig */;
 			buildSettings = {
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_PREFIX_HEADER = "Target Support Files/Pods-EditorDemo-AFNetworking/Pods-EditorDemo-AFNetworking-prefix.pch";
@@ -2145,9 +2117,25 @@
 			};
 			name = Release;
 		};
-		406914A9A0D3AE0C1B33CC24 /* Release */ = {
+		07969ED1FA631946373B8C14 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 6A5A0E79F9A6A2E44FD39CED /* Pods-EditorDemoTests.release.xcconfig */;
+			baseConfigurationReference = EB11CD05067DAEC2892329BD /* Pods-EditorDemoTests.debug.xcconfig */;
+			buildSettings = {
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PODS_ROOT = "$(SRCROOT)";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		085E260BD3CA5C4053AED754 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = F5F7833A0169DF03AAF37725 /* Pods-EditorDemoTests.release.xcconfig */;
 			buildSettings = {
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
@@ -2161,24 +2149,12 @@
 			};
 			name = Release;
 		};
-		59B492DB0BD4FA35CEB54B10 /* Debug */ = {
+		09E802E0B855360DA3F41C89 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = CED050E53B65F55252827DB2 /* Pods-EditorDemo-WordPress-iOS-Shared-Private.xcconfig */;
+			baseConfigurationReference = F2C07F7D3B78CFCEAC52945D /* Pods-EditorDemo-AFNetworking-Private.xcconfig */;
 			buildSettings = {
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				PRODUCT_NAME = "WordPress-iOS-Shared";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				WRAPPER_EXTENSION = bundle;
-			};
-			name = Debug;
-		};
-		5A5FB3B481262964ECF7752D /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 66CB0A484B346F4A872A79AE /* Pods-EditorDemoTests-CocoaLumberjack-Private.xcconfig */;
-			buildSettings = {
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/Pods-EditorDemoTests-CocoaLumberjack/Pods-EditorDemoTests-CocoaLumberjack-prefix.pch";
+				GCC_PREFIX_HEADER = "Target Support Files/Pods-EditorDemo-AFNetworking/Pods-EditorDemo-AFNetworking-prefix.pch";
 				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				OTHER_LDFLAGS = "";
@@ -2189,9 +2165,161 @@
 			};
 			name = Debug;
 		};
-		62C9C0EBE6216058063DF6EE /* Debug */ = {
+		0C1624FD97B3280B415547C5 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = CED050E53B65F55252827DB2 /* Pods-EditorDemo-WordPress-iOS-Shared-Private.xcconfig */;
+			baseConfigurationReference = B2445A05A99FF8B7B37E9A00 /* Pods-EditorDemo-WordPress-iOS-Shared-Private.xcconfig */;
+			buildSettings = {
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				PRODUCT_NAME = "WordPress-iOS-Shared";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				WRAPPER_EXTENSION = bundle;
+			};
+			name = Debug;
+		};
+		0FF6759EF937D15FAD7BF355 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = B2445A05A99FF8B7B37E9A00 /* Pods-EditorDemo-WordPress-iOS-Shared-Private.xcconfig */;
+			buildSettings = {
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/Pods-EditorDemo-WordPress-iOS-Shared/Pods-EditorDemo-WordPress-iOS-Shared-prefix.pch";
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
+		192FFEE5E513C3C3D07E896E /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = D8533A19FBA3CA1A2209E485 /* Pods-EditorDemo-UIAlertView+Blocks-Private.xcconfig */;
+			buildSettings = {
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/Pods-EditorDemo-UIAlertView+Blocks/Pods-EditorDemo-UIAlertView+Blocks-prefix.pch";
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
+		33967CD5CFA835A022E72EC2 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 6A98ABB91F55F02BCDFEF6BA /* Pods-EditorDemo.debug.xcconfig */;
+			buildSettings = {
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PODS_ROOT = "$(SRCROOT)";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		48432FC3639AB53EA87CF0D7 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = D8533A19FBA3CA1A2209E485 /* Pods-EditorDemo-UIAlertView+Blocks-Private.xcconfig */;
+			buildSettings = {
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/Pods-EditorDemo-UIAlertView+Blocks/Pods-EditorDemo-UIAlertView+Blocks-prefix.pch";
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		4CCB0D6B4DD1BC6DC007E2C7 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 804362E3A200B38A7E623C87 /* Pods-EditorDemo-NSObject-SafeExpectations-Private.xcconfig */;
+			buildSettings = {
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/Pods-EditorDemo-NSObject-SafeExpectations/Pods-EditorDemo-NSObject-SafeExpectations-prefix.pch";
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		8FFF7EFF6C0C8691B85D21F5 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = EEFB446E2FD00B86FE17D354 /* Pods-EditorDemo.release.xcconfig */;
+			buildSettings = {
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PODS_ROOT = "$(SRCROOT)";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
+		AF8B0AA27E4F77F93A1C0EB9 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 804362E3A200B38A7E623C87 /* Pods-EditorDemo-NSObject-SafeExpectations-Private.xcconfig */;
+			buildSettings = {
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/Pods-EditorDemo-NSObject-SafeExpectations/Pods-EditorDemo-NSObject-SafeExpectations-prefix.pch";
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
+		B164B4D5D90BAE8834F4F62C /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = B2445A05A99FF8B7B37E9A00 /* Pods-EditorDemo-WordPress-iOS-Shared-Private.xcconfig */;
+			buildSettings = {
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				PRODUCT_NAME = "WordPress-iOS-Shared";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				WRAPPER_EXTENSION = bundle;
+			};
+			name = Release;
+		};
+		BF208BBD8755BD719CED8944 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 3FDA9FF74C52D9ECF0E91763 /* Pods-EditorDemoTests-CocoaLumberjack-Private.xcconfig */;
+			buildSettings = {
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/Pods-EditorDemoTests-CocoaLumberjack/Pods-EditorDemoTests-CocoaLumberjack-prefix.pch";
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
+		C35253297E5EC9F21CB0C880 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = B2445A05A99FF8B7B37E9A00 /* Pods-EditorDemo-WordPress-iOS-Shared-Private.xcconfig */;
 			buildSettings = {
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_PREFIX_HEADER = "Target Support Files/Pods-EditorDemo-WordPress-iOS-Shared/Pods-EditorDemo-WordPress-iOS-Shared-prefix.pch";
@@ -2205,9 +2333,9 @@
 			};
 			name = Debug;
 		};
-		867E353D1B799F15A934351F /* Release */ = {
+		C61D15A57053753823117CE1 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 1ACB5D3CD0353F368F0C28A2 /* Pods-EditorDemo-WordPress-iOS-Editor-Private.xcconfig */;
+			baseConfigurationReference = B9DA7B876D2652FCDAB214CA /* Pods-EditorDemo-WordPress-iOS-Editor-Private.xcconfig */;
 			buildSettings = {
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_PREFIX_HEADER = "Target Support Files/Pods-EditorDemo-WordPress-iOS-Editor/Pods-EditorDemo-WordPress-iOS-Editor-prefix.pch";
@@ -2221,105 +2349,41 @@
 			};
 			name = Release;
 		};
-		8B82314A2B7C5165E085A4F5 /* Debug */ = {
+		D19D106AC4D09A29403939B9 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 2BB0FEADE5DDFD462933EC4D /* Pods-EditorDemo-NSObject-SafeExpectations-Private.xcconfig */;
-			buildSettings = {
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/Pods-EditorDemo-NSObject-SafeExpectations/Pods-EditorDemo-NSObject-SafeExpectations-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
-				MTL_ENABLE_DEBUG_INFO = YES;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-			};
-			name = Debug;
-		};
-		907DD5846A7C4EB0964DA8D8 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 2BB0FEADE5DDFD462933EC4D /* Pods-EditorDemo-NSObject-SafeExpectations-Private.xcconfig */;
-			buildSettings = {
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/Pods-EditorDemo-NSObject-SafeExpectations/Pods-EditorDemo-NSObject-SafeExpectations-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
-				MTL_ENABLE_DEBUG_INFO = NO;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-			};
-			name = Release;
-		};
-		933EECA0312D74B7C425DC33 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = CED050E53B65F55252827DB2 /* Pods-EditorDemo-WordPress-iOS-Shared-Private.xcconfig */;
-			buildSettings = {
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/Pods-EditorDemo-WordPress-iOS-Shared/Pods-EditorDemo-WordPress-iOS-Shared-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
-				MTL_ENABLE_DEBUG_INFO = NO;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-			};
-			name = Release;
-		};
-		9DCDA0990967B1B2505D8AEB /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 66CB0A484B346F4A872A79AE /* Pods-EditorDemoTests-CocoaLumberjack-Private.xcconfig */;
+			baseConfigurationReference = 3FDA9FF74C52D9ECF0E91763 /* Pods-EditorDemoTests-CocoaLumberjack-Private.xcconfig */;
 			buildSettings = {
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_PREFIX_HEADER = "Target Support Files/Pods-EditorDemoTests-CocoaLumberjack/Pods-EditorDemoTests-CocoaLumberjack-prefix.pch";
 				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
-				MTL_ENABLE_DEBUG_INFO = NO;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-			};
-			name = Release;
-		};
-		B48C44BEDC1AEFFF1FF03F8D /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 4DAD4EFB895576377C6D6421 /* Pods-EditorDemo-WordPressCom-Analytics-iOS-Private.xcconfig */;
-			buildSettings = {
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/Pods-EditorDemo-WordPressCom-Analytics-iOS/Pods-EditorDemo-WordPressCom-Analytics-iOS-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
-				MTL_ENABLE_DEBUG_INFO = NO;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-			};
-			name = Release;
-		};
-		B7D9ACA9FB98DE050A888817 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 7291752A749BD1FB9C8FD07B /* Pods-EditorDemo.debug.xcconfig */;
-			buildSettings = {
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
-				PODS_ROOT = "$(SRCROOT)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 			};
 			name = Debug;
 		};
-		C5C50FF86D78ED5B14A064AF /* Debug */ = {
+		D42F652FDD25023A63CE234E /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 95625436A073EB8182AEF56A /* Pods-EditorDemo-CocoaLumberjack-Private.xcconfig */;
+			baseConfigurationReference = A2F7B749D27EDAD85F31094B /* Pods-EditorDemo-CocoaLumberjack-Private.xcconfig */;
+			buildSettings = {
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/Pods-EditorDemo-CocoaLumberjack/Pods-EditorDemo-CocoaLumberjack-prefix.pch";
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
+		DCD08D6F8DFE86686D07DF83 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = A2F7B749D27EDAD85F31094B /* Pods-EditorDemo-CocoaLumberjack-Private.xcconfig */;
 			buildSettings = {
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_PREFIX_HEADER = "Target Support Files/Pods-EditorDemo-CocoaLumberjack/Pods-EditorDemo-CocoaLumberjack-prefix.pch";
@@ -2333,23 +2397,39 @@
 			};
 			name = Debug;
 		};
-		D4B79BF136B3644EB92C3665 /* Debug */ = {
+		E5A78C75B7B2C29A3F8F8B5D /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 5F85D8AA92A66EF2E1DDA8E9 /* Pods-EditorDemoTests.debug.xcconfig */;
+			baseConfigurationReference = B9DA7B876D2652FCDAB214CA /* Pods-EditorDemo-WordPress-iOS-Editor-Private.xcconfig */;
 			buildSettings = {
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/Pods-EditorDemo-WordPress-iOS-Editor/Pods-EditorDemo-WordPress-iOS-Editor-prefix.pch";
 				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
-				PODS_ROOT = "$(SRCROOT)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 			};
 			name = Debug;
 		};
-		D911AD3D3576DBC5AC0EC4EE /* Release */ = {
+		E6A4077495B235A1DDFCE96C /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = C5FBE421BE6715DE7A8087E9 /* Pods-EditorDemo-WordPressCom-Analytics-iOS-Private.xcconfig */;
+			buildSettings = {
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/Pods-EditorDemo-WordPressCom-Analytics-iOS/Pods-EditorDemo-WordPressCom-Analytics-iOS-prefix.pch";
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		EFC6930BCB57CBF86A530F4E /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -2383,214 +2463,134 @@
 			};
 			name = Release;
 		};
-		EA700B1F83BE7580CBDB3F28 /* Release */ = {
+		F82EFCB23BBF4D644C08E4E7 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 4405DA15440A4795151956A8 /* Pods-EditorDemo-UIAlertView+Blocks-Private.xcconfig */;
-			buildSettings = {
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/Pods-EditorDemo-UIAlertView+Blocks/Pods-EditorDemo-UIAlertView+Blocks-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
-				MTL_ENABLE_DEBUG_INFO = NO;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-			};
-			name = Release;
-		};
-		F4171ADC26157D79D4E642EC /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = C74D92E6172B18645410B660 /* Pods-EditorDemo-AFNetworking-Private.xcconfig */;
-			buildSettings = {
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/Pods-EditorDemo-AFNetworking/Pods-EditorDemo-AFNetworking-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
-				MTL_ENABLE_DEBUG_INFO = YES;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-			};
-			name = Debug;
-		};
-		F627A04E1A5F8A065B3A1BAB /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 6F77D6834FCEB81B689C42BA /* Pods-EditorDemo.release.xcconfig */;
-			buildSettings = {
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
-				MTL_ENABLE_DEBUG_INFO = NO;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PODS_ROOT = "$(SRCROOT)";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-			};
-			name = Release;
-		};
-		F796B16D5F9215BF1F991BE0 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 1ACB5D3CD0353F368F0C28A2 /* Pods-EditorDemo-WordPress-iOS-Editor-Private.xcconfig */;
-			buildSettings = {
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/Pods-EditorDemo-WordPress-iOS-Editor/Pods-EditorDemo-WordPress-iOS-Editor-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
-				MTL_ENABLE_DEBUG_INFO = YES;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-			};
-			name = Debug;
-		};
-		FCFAD27431396C37D8672CE8 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 4DAD4EFB895576377C6D6421 /* Pods-EditorDemo-WordPressCom-Analytics-iOS-Private.xcconfig */;
+			baseConfigurationReference = C5FBE421BE6715DE7A8087E9 /* Pods-EditorDemo-WordPressCom-Analytics-iOS-Private.xcconfig */;
 			buildSettings = {
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_PREFIX_HEADER = "Target Support Files/Pods-EditorDemo-WordPressCom-Analytics-iOS/Pods-EditorDemo-WordPressCom-Analytics-iOS-prefix.pch";
 				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
-				MTL_ENABLE_DEBUG_INFO = YES;
+				MTL_ENABLE_DEBUG_INFO = NO;
 				OTHER_LDFLAGS = "";
 				OTHER_LIBTOOLFLAGS = "";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 			};
-			name = Debug;
-		};
-		FF65440A55FEF477DEC81D07 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 4405DA15440A4795151956A8 /* Pods-EditorDemo-UIAlertView+Blocks-Private.xcconfig */;
-			buildSettings = {
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/Pods-EditorDemo-UIAlertView+Blocks/Pods-EditorDemo-UIAlertView+Blocks-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
-				MTL_ENABLE_DEBUG_INFO = YES;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-			};
-			name = Debug;
+			name = Release;
 		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		29F2ACFBADD8E7DBF87BB4B8 /* Build configuration list for PBXNativeTarget "Pods-EditorDemo" */ = {
+		13F785D3AC37FC4B00C48326 /* Build configuration list for PBXNativeTarget "Pods-EditorDemoTests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				B7D9ACA9FB98DE050A888817 /* Debug */,
-				F627A04E1A5F8A065B3A1BAB /* Release */,
+				07969ED1FA631946373B8C14 /* Debug */,
+				085E260BD3CA5C4053AED754 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		2FED5201A426698EA0D1289E /* Build configuration list for PBXNativeTarget "Pods-EditorDemo-WordPress-iOS-Shared" */ = {
+		1A6E4F61DBBF611EFAF46824 /* Build configuration list for PBXNativeTarget "Pods-EditorDemo-WordPress-iOS-Shared-WordPress-iOS-Shared" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				62C9C0EBE6216058063DF6EE /* Debug */,
-				933EECA0312D74B7C425DC33 /* Release */,
+				0C1624FD97B3280B415547C5 /* Debug */,
+				B164B4D5D90BAE8834F4F62C /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		46B8FE4256F90758A0033BC3 /* Build configuration list for PBXNativeTarget "Pods-EditorDemo-UIAlertView+Blocks" */ = {
+		41B4E40C70D9E1DEA516CCFD /* Build configuration list for PBXNativeTarget "Pods-EditorDemoTests-CocoaLumberjack" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				FF65440A55FEF477DEC81D07 /* Debug */,
-				EA700B1F83BE7580CBDB3F28 /* Release */,
+				D19D106AC4D09A29403939B9 /* Debug */,
+				BF208BBD8755BD719CED8944 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		643FD4FF3B03953AD73EB522 /* Build configuration list for PBXNativeTarget "Pods-EditorDemo-WordPress-iOS-Editor" */ = {
+		4C75839609962EA00DDD06A0 /* Build configuration list for PBXNativeTarget "Pods-EditorDemo-CocoaLumberjack" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				F796B16D5F9215BF1F991BE0 /* Debug */,
-				867E353D1B799F15A934351F /* Release */,
+				DCD08D6F8DFE86686D07DF83 /* Debug */,
+				D42F652FDD25023A63CE234E /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		76A7D8816B96D7F1976C7DC1 /* Build configuration list for PBXNativeTarget "Pods-EditorDemo-WordPress-iOS-Shared-WordPress-iOS-Shared" */ = {
+		55E3F6CF5B4E038187635D46 /* Build configuration list for PBXNativeTarget "Pods-EditorDemo-WordPress-iOS-Editor" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				59B492DB0BD4FA35CEB54B10 /* Debug */,
-				11797432C89843D2520C0FC0 /* Release */,
+				E5A78C75B7B2C29A3F8F8B5D /* Debug */,
+				C61D15A57053753823117CE1 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		8255DBC7EF8E80A76140600F /* Build configuration list for PBXNativeTarget "Pods-EditorDemo-AFNetworking" */ = {
+		66B79A2B70175FEC130294E3 /* Build configuration list for PBXNativeTarget "Pods-EditorDemo-WordPress-iOS-Shared" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				F4171ADC26157D79D4E642EC /* Debug */,
-				3A257DE87A6BA1416A591D26 /* Release */,
+				C35253297E5EC9F21CB0C880 /* Debug */,
+				0FF6759EF937D15FAD7BF355 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		85CC5C109523381F99BC1D37 /* Build configuration list for PBXNativeTarget "Pods-EditorDemo-NSObject-SafeExpectations" */ = {
+		734B4E40B6BCD8F991F5BDEA /* Build configuration list for PBXNativeTarget "Pods-EditorDemo-AFNetworking" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				8B82314A2B7C5165E085A4F5 /* Debug */,
-				907DD5846A7C4EB0964DA8D8 /* Release */,
+				09E802E0B855360DA3F41C89 /* Debug */,
+				021CD7737D4BDC9E38C06713 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		C0650FCD48ADB9419850E17A /* Build configuration list for PBXNativeTarget "Pods-EditorDemoTests-CocoaLumberjack" */ = {
+		761444A6F6B9B3548443F37D /* Build configuration list for PBXNativeTarget "Pods-EditorDemo" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				5A5FB3B481262964ECF7752D /* Debug */,
-				9DCDA0990967B1B2505D8AEB /* Release */,
+				33967CD5CFA835A022E72EC2 /* Debug */,
+				8FFF7EFF6C0C8691B85D21F5 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		E37D513A08AC2C2A32DF2A5F /* Build configuration list for PBXProject "Pods" */ = {
+		AA227CC47B3A51AAA6010D9F /* Build configuration list for PBXNativeTarget "Pods-EditorDemo-NSObject-SafeExpectations" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				060DE70B54F89D1C6F6758FE /* Debug */,
-				D911AD3D3576DBC5AC0EC4EE /* Release */,
+				4CCB0D6B4DD1BC6DC007E2C7 /* Debug */,
+				AF8B0AA27E4F77F93A1C0EB9 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		E9D3BBD89D8810AB4AB8F64F /* Build configuration list for PBXNativeTarget "Pods-EditorDemo-WordPressCom-Analytics-iOS" */ = {
+		B3623581EEB6F962C6577689 /* Build configuration list for PBXProject "Pods" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				FCFAD27431396C37D8672CE8 /* Debug */,
-				B48C44BEDC1AEFFF1FF03F8D /* Release */,
+				006357B7652DB0D04133246E /* Debug */,
+				EFC6930BCB57CBF86A530F4E /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		ED454E094533C7A6DA367B65 /* Build configuration list for PBXNativeTarget "Pods-EditorDemo-CocoaLumberjack" */ = {
+		B5095AAC24E7598010D749F0 /* Build configuration list for PBXNativeTarget "Pods-EditorDemo-UIAlertView+Blocks" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				C5C50FF86D78ED5B14A064AF /* Debug */,
-				127E4421CCC5868AAD10FD74 /* Release */,
+				48432FC3639AB53EA87CF0D7 /* Debug */,
+				192FFEE5E513C3C3D07E896E /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		F2C219259EF552112F49BEC6 /* Build configuration list for PBXNativeTarget "Pods-EditorDemoTests" */ = {
+		DA9057388106BD5B20C9A20D /* Build configuration list for PBXNativeTarget "Pods-EditorDemo-WordPressCom-Analytics-iOS" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				D4B79BF136B3644EB92C3665 /* Debug */,
-				406914A9A0D3AE0C1B33CC24 /* Release */,
+				E6A4077495B235A1DDFCE96C /* Debug */,
+				F82EFCB23BBF4D644C08E4E7 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 	};
-	rootObject = 8271F7CE20E8F531623E8A97 /* Project object */;
+	rootObject = F0816A4D6FC502289658307E /* Project object */;
 }

--- a/Example/Pods/Pods.xcodeproj/xcshareddata/xcschemes/Pods-EditorDemo-WordPress-iOS-Editor.xcscheme
+++ b/Example/Pods/Pods.xcodeproj/xcshareddata/xcschemes/Pods-EditorDemo-WordPress-iOS-Editor.xcscheme
@@ -14,7 +14,7 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "F735F3AFF58FF4215065D9F1"
+               BlueprintIdentifier = "2DF9E43CC1FCA5E4B490292F"
                BuildableName = "libPods-EditorDemo-WordPress-iOS-Editor.a"
                BlueprintName = "Pods-EditorDemo-WordPress-iOS-Editor"
                ReferencedContainer = "container:Pods.xcodeproj">


### PR DESCRIPTION
Address part of #694. In short we are reverting all scrolling on the format bar. It should fit nicely on all sizes of phones (iPads will stay the same). This PR also fixes the HTML button, which was not using the latest "HTML" icon.

/cc @astralbodies 