### PR TITLE
Links now open correctly in preview mode.

### DIFF
--- a/Classes/WPEditorViewController.m
+++ b/Classes/WPEditorViewController.m
@@ -1636,6 +1636,8 @@ NSInteger const WPLinkAlertViewTag = 92;
 	if (self.isEditing) {
         [self showInsertLinkDialogWithLink:url.absoluteString
                                      title:title];
+	} else {
+		[[UIApplication sharedApplication] openURL:url];
 	}
 	
 	return YES;


### PR DESCRIPTION
Fixes [this issue](https://github.com/wordpress-mobile/WordPress-Editor-iOS/issues/699).

**To test:**
1. Create a post with a link
2. Tap "edit" to switch to preview mode.
3. Tap the link.
4. Make sure the link opens in Safari.app.

/cc @bummytime 