### PR TITLE
Remove iOS9 warnings

### DIFF
--- a/Classes/HRColorPickerView.m
+++ b/Classes/HRColorPickerView.m
@@ -59,7 +59,7 @@
 
 + (HRColorPickerStyle)fitScreenStyle
 {
-    CGSize defaultSize = [[UIScreen mainScreen] applicationFrame].size;
+    CGSize defaultSize = [UIApplication sharedApplication].keyWindow.bounds.size;
     defaultSize.height -= 44.f;
     
     HRColorPickerStyle style = [HRColorPickerView defaultStyle];

--- a/Classes/HRColorPickerViewController.m
+++ b/Classes/HRColorPickerViewController.m
@@ -74,7 +74,7 @@
 
 - (void)loadView
 {
-    CGRect frame = [[UIScreen mainScreen] applicationFrame];
+    CGRect frame = [UIApplication sharedApplication].keyWindow.bounds;
     frame.size.height -= 44.f;
     
     self.view = [[UIView alloc] initWithFrame:frame];

--- a/Classes/WPEditorView.m
+++ b/Classes/WPEditorView.m
@@ -1333,7 +1333,7 @@ shouldStartLoadWithRequest:(NSURLRequest *)request
 - (NSString *)stringByDecodingURLFormat:(NSString *)string
 {
     NSString *result = [string stringByReplacingOccurrencesOfString:@"+" withString:@" "];
-    result = [result stringByReplacingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
+    result = [result stringByRemovingPercentEncoding];
     return result;
 }
 

--- a/Classes/WPLegacyEditorViewController.m
+++ b/Classes/WPLegacyEditorViewController.m
@@ -37,6 +37,7 @@ CGFloat const WPLegacyEPVCTextViewTopPadding = 7.0f;
         self.view.backgroundColor = [WPStyleGuide itsEverywhereGrey];
     }
     self.navigationController.navigationBar.translucent = NO;
+    self.modalPresentationCapturesStatusBarAppearance = YES;
     [self setupToolbar];
     [self setupTextView];
     [self setupOptionsView];
@@ -643,6 +644,18 @@ CGFloat const WPLegacyEPVCTextViewTopPadding = 7.0f;
     self.titleToolbar.frame = frame; // Frames match, no need to re-calc.
 }
 
+#pragma mark - Status bar management
+
+- (BOOL)prefersStatusBarHidden
+{
+    return self.isShowingKeyboard;
+}
+
+- (UIStatusBarAnimation)preferredStatusBarUpdateAnimation
+{
+    return UIStatusBarAnimationSlide;
+}
+
 #pragma mark - Keyboard management
 
 - (void)keyboardWillShow:(NSNotification *)notification
@@ -650,7 +663,7 @@ CGFloat const WPLegacyEPVCTextViewTopPadding = 7.0f;
 	self.isShowingKeyboard = YES;
     
     if ([self shouldHideToolbarsWhileTyping]) {
-        [[UIApplication sharedApplication] setStatusBarHidden:YES withAnimation:UIStatusBarAnimationFade];
+        [self setNeedsStatusBarAppearanceUpdate];
         [self.navigationController setNavigationBarHidden:YES animated:YES];
         [self.navigationController setToolbarHidden:YES animated:NO];
     }
@@ -670,7 +683,7 @@ CGFloat const WPLegacyEPVCTextViewTopPadding = 7.0f;
 - (void)keyboardWillHide:(NSNotification *)notification
 {
 	self.isShowingKeyboard = NO;
-    [[UIApplication sharedApplication] setStatusBarHidden:NO withAnimation:UIStatusBarAnimationFade];
+    [self setNeedsStatusBarAppearanceUpdate];
     [self.navigationController setNavigationBarHidden:NO animated:YES];
     [self.navigationController setToolbarHidden:NO animated:NO];
     [self positionTextView:notification];

--- a/Example/EditorDemo/WPAppDelegate.m
+++ b/Example/EditorDemo/WPAppDelegate.m
@@ -8,7 +8,7 @@
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
     //Default to white
-    [[UIToolbar appearanceWhenContainedIn:[WPEditorViewController class], nil] setBarTintColor:[UIColor whiteColor]];
+    [[UIToolbar appearanceWhenContainedInInstancesOfClasses:@[[WPEditorViewController class]]] setBarTintColor:[UIColor whiteColor]];
     
     [DDLog addLogger:[DDASLLogger sharedInstance]];
     [DDLog addLogger:[DDTTYLogger sharedInstance]];

--- a/Example/EditorDemo/WPViewController.m
+++ b/Example/EditorDemo/WPViewController.m
@@ -7,15 +7,7 @@
 #import "WPEditorView.h"
 #import "WPImageMetaViewController.h"
 
-typedef NS_ENUM(NSUInteger,  WPViewControllerActionSheet) {
-    WPViewControllerActionSheetImageUploadStop = 200,
-    WPViewControllerActionSheetImageUploadRetry = 201,
-    WPViewControllerActionSheetVideoUploadStop = 202,
-    WPViewControllerActionSheetVideoUploadRetry = 203
-
-};
-
-@interface WPViewController () <UINavigationControllerDelegate, UIImagePickerControllerDelegate, UIActionSheetDelegate, WPImageMetaViewControllerDelegate>
+@interface WPViewController () <UINavigationControllerDelegate, UIImagePickerControllerDelegate, WPImageMetaViewControllerDelegate>
 @property(nonatomic, strong) NSMutableDictionary *mediaAdded;
 @property(nonatomic, strong) NSString *selectedMediaID;
 @property(nonatomic, strong) NSCache *videoPressCache;
@@ -173,17 +165,59 @@ typedef NS_ENUM(NSUInteger,  WPViewControllerActionSheet) {
     if (imageId.length == 0){
         return;
     }
+    
+    __weak __typeof(self)weakSelf = self;
+    UITraitCollection *traits = self.navigationController.traitCollection;
     NSProgress *progress = self.mediaAdded[imageId];
-    if (!progress.cancelled){
-        UIActionSheet *actionSheet = [[UIActionSheet alloc] initWithTitle:nil delegate:self cancelButtonTitle:@"Cancel" destructiveButtonTitle:@"Stop Upload" otherButtonTitles:nil];
-        [actionSheet showInView:self.view];
-        actionSheet.tag = WPViewControllerActionSheetImageUploadStop;
+    UIAlertController *alertController;
+    if (traits.userInterfaceIdiom == UIUserInterfaceIdiomPad) {
+        alertController = [UIAlertController alertControllerWithTitle:nil
+                                                              message:nil
+                                                       preferredStyle:UIAlertControllerStyleAlert];
     } else {
-        UIActionSheet *actionSheet = [[UIActionSheet alloc] initWithTitle:nil delegate:self cancelButtonTitle:@"Cancel" destructiveButtonTitle:@"Remove Image" otherButtonTitles:@"Retry Upload", nil];
-        [actionSheet showInView:self.view];
-        actionSheet.tag = WPViewControllerActionSheetImageUploadRetry;
+        alertController = [UIAlertController alertControllerWithTitle:nil
+                                                              message:nil
+                                                       preferredStyle:UIAlertControllerStyleActionSheet];
     }
+    
+    UIAlertAction *cancelAction = [UIAlertAction actionWithTitle:@"Cancel"
+                                                           style:UIAlertActionStyleCancel
+                                                         handler:^(UIAlertAction *action){}];
+    [alertController addAction:cancelAction];
+    
+    if (!progress.cancelled){
+        UIAlertAction *stopAction = [UIAlertAction actionWithTitle:@"Stop Upload"
+                                                             style:UIAlertActionStyleDestructive
+                                                           handler:^(UIAlertAction *action){
+                                                               [weakSelf.editorView removeImage:weakSelf.selectedMediaID];
+                                                           }];
+        [alertController addAction:stopAction];
+    } else {
+        UIAlertAction *removeAction = [UIAlertAction actionWithTitle:@"Remove Image"
+                                                               style:UIAlertActionStyleDestructive
+                                                             handler:^(UIAlertAction *action){
+                                                                 [weakSelf.editorView removeImage:weakSelf.selectedMediaID];
+                                                             }];
+        
+        UIAlertAction *retryAction = [UIAlertAction actionWithTitle:@"Retry Upload"
+                                                              style:UIAlertActionStyleDefault
+                                                            handler:^(UIAlertAction *action){
+                                                                NSProgress * progress = [[NSProgress alloc] initWithParent:nil userInfo:@{@"imageID":self.selectedMediaID}];
+                                                                progress.totalUnitCount = 100;
+                                                                [NSTimer scheduledTimerWithTimeInterval:0.1
+                                                                                                 target:self
+                                                                                               selector:@selector(timerFireMethod:)
+                                                                                               userInfo:progress
+                                                                                                repeats:YES];
+                                                                weakSelf.mediaAdded[weakSelf.selectedMediaID] = progress;
+                                                                [weakSelf.editorView unmarkImageFailedUpload:weakSelf.selectedMediaID];
+                                                            }];
+        [alertController addAction:removeAction];
+        [alertController addAction:retryAction];
+    }
+    
     self.selectedMediaID = imageId;
+    [self.navigationController presentViewController:alertController animated:YES completion:nil];
 }
 
 - (void)showPromptForVideoWithID:(NSString *)videoId
@@ -191,17 +225,57 @@ typedef NS_ENUM(NSUInteger,  WPViewControllerActionSheet) {
     if (videoId.length == 0){
         return;
     }
+    __weak __typeof(self)weakSelf = self;
+    UITraitCollection *traits = self.navigationController.traitCollection;
     NSProgress *progress = self.mediaAdded[videoId];
-    if (!progress.cancelled){
-        UIActionSheet *actionSheet = [[UIActionSheet alloc] initWithTitle:nil delegate:self cancelButtonTitle:@"Cancel" destructiveButtonTitle:@"Stop Upload" otherButtonTitles:nil];
-        [actionSheet showInView:self.view];
-        actionSheet.tag = WPViewControllerActionSheetVideoUploadStop;
+    UIAlertController *alertController;
+    if (traits.userInterfaceIdiom == UIUserInterfaceIdiomPad) {
+        alertController = [UIAlertController alertControllerWithTitle:nil
+                                                              message:nil
+                                                       preferredStyle:UIAlertControllerStyleAlert];
     } else {
-        UIActionSheet *actionSheet = [[UIActionSheet alloc] initWithTitle:nil delegate:self cancelButtonTitle:@"Cancel" destructiveButtonTitle:@"Remove Video" otherButtonTitles:@"Retry Upload", nil];
-        [actionSheet showInView:self.view];
-        actionSheet.tag = WPViewControllerActionSheetVideoUploadRetry;
+        alertController = [UIAlertController alertControllerWithTitle:nil
+                                                              message:nil
+                                                       preferredStyle:UIAlertControllerStyleActionSheet];
+    }
+    
+    UIAlertAction *cancelAction = [UIAlertAction actionWithTitle:@"Cancel"
+                                                           style:UIAlertActionStyleCancel
+                                                         handler:^(UIAlertAction *action){}];
+    [alertController addAction:cancelAction];
+    
+    if (!progress.cancelled){
+        UIAlertAction *stopAction = [UIAlertAction actionWithTitle:@"Stop Upload"
+                                                             style:UIAlertActionStyleDestructive
+                                                           handler:^(UIAlertAction *action){
+                                                               [weakSelf.editorView removeVideo:weakSelf.selectedMediaID];
+                                                           }];
+        [alertController addAction:stopAction];
+    } else {
+        UIAlertAction *removeAction = [UIAlertAction actionWithTitle:@"Remove Video"
+                                                               style:UIAlertActionStyleDestructive
+                                                             handler:^(UIAlertAction *action){
+                                                                 [weakSelf.editorView removeVideo:weakSelf.selectedMediaID];
+                                                             }];
+        
+        UIAlertAction *retryAction = [UIAlertAction actionWithTitle:@"Retry Upload"
+                                                              style:UIAlertActionStyleDefault
+                                                            handler:^(UIAlertAction *action){
+                                                                NSProgress * progress = [[NSProgress alloc] initWithParent:nil userInfo:@{@"videoID":weakSelf.selectedMediaID}];
+                                                                progress.totalUnitCount = 100;
+                                                                [NSTimer scheduledTimerWithTimeInterval:0.1
+                                                                                                 target:self
+                                                                                               selector:@selector(timerFireMethod:)
+                                                                                               userInfo:progress
+                                                                                                repeats:YES];
+                                                                weakSelf.mediaAdded[self.selectedMediaID] = progress;
+                                                                [weakSelf.editorView unmarkVideoFailedUpload:weakSelf.selectedMediaID];
+                                                            }];
+        [alertController addAction:removeAction];
+        [alertController addAction:retryAction];
     }
     self.selectedMediaID = videoId;
+    [self.navigationController presentViewController:alertController animated:YES completion:nil];
 }
 
 - (void)showPhotoPicker
@@ -344,54 +418,6 @@ typedef NS_ENUM(NSUInteger,  WPViewControllerActionSheet) {
         NSURL *assetURL = info[UIImagePickerControllerReferenceURL];
         [self addAssetToContent:assetURL];
     }];
-    
-}
-
-#pragma mark - UIActionSheetDelegate
-
-- (void)actionSheet:(UIActionSheet *)actionSheet clickedButtonAtIndex:(NSInteger)buttonIndex
-{
-    if (actionSheet.tag == WPViewControllerActionSheetImageUploadStop){
-        if (buttonIndex == actionSheet.destructiveButtonIndex) {
-            [self.editorView removeImage:self.selectedMediaID];
-        }
-    } else if (actionSheet.tag == WPViewControllerActionSheetImageUploadRetry){
-        if (buttonIndex == actionSheet.destructiveButtonIndex) {
-            [self.editorView removeImage:self.selectedMediaID];
-        } else if (buttonIndex == actionSheet.firstOtherButtonIndex) {
-            NSProgress * progress = [[NSProgress alloc] initWithParent:nil userInfo:@{@"imageID":self.selectedMediaID}];
-            progress.totalUnitCount = 100;
-            [NSTimer scheduledTimerWithTimeInterval:0.1
-                                             target:self
-                                           selector:@selector(timerFireMethod:)
-                                           userInfo:progress
-                                            repeats:YES];
-            self.mediaAdded[self.selectedMediaID] = progress;
-            [self.editorView unmarkImageFailedUpload:self.selectedMediaID];
-        }
-
-    } else if (actionSheet.tag == WPViewControllerActionSheetVideoUploadStop){
-        if (buttonIndex == actionSheet.destructiveButtonIndex) {
-            [self.editorView removeVideo:self.selectedMediaID];
-        }
-    } else if (actionSheet.tag == WPViewControllerActionSheetVideoUploadRetry){
-        if (buttonIndex == actionSheet.destructiveButtonIndex) {
-            [self.editorView removeVideo:self.selectedMediaID];
-        } else if (buttonIndex == actionSheet.firstOtherButtonIndex) {
-            NSProgress * progress = [[NSProgress alloc] initWithParent:nil userInfo:@{@"videoID":self.selectedMediaID}];
-            progress.totalUnitCount = 100;
-            [NSTimer scheduledTimerWithTimeInterval:0.1
-                                             target:self
-                                           selector:@selector(timerFireMethod:)
-                                           userInfo:progress
-                                            repeats:YES];
-            self.mediaAdded[self.selectedMediaID] = progress;
-            [self.editorView unmarkVideoFailedUpload:self.selectedMediaID];
-        }
-        
-    }
-
-    
     
 }
 

--- a/Example/EditorDemo/WPViewController.m
+++ b/Example/EditorDemo/WPViewController.m
@@ -30,7 +30,7 @@ typedef NS_ENUM(NSUInteger,  WPViewControllerActionSheet) {
     
     self.delegate = self;
     self.navigationItem.leftBarButtonItem = [[UIBarButtonItem alloc] initWithTitle:@"Edit"
-                                                                             style:UIBarButtonItemStyleBordered
+                                                                             style:UIBarButtonItemStylePlain
                                                                             target:self
                                                                             action:@selector(editTouchedUpInside)];
     self.mediaAdded = [NSMutableDictionary dictionary];


### PR DESCRIPTION
Fixes #727 

This PR removes all warnings from the editor and editor demo *except* for `ALAsset` warnings (which are isolated to the demo project only).

**Things to test (iPad and iPhone):**
- New Editor: Tapping a URL link in the editor (no title)
- Legacy Editor: status bar hiding (unfortunately we cannot test in the demo)
- Editor Demo: Action sheet that appears when tapping an uploading image
- Editor Demo: Action sheet that appears when tapping an image that failed uploading (see [here](https://github.com/wordpress-mobile/WordPress-Editor-iOS/blob/ff1adff26ed5c6624278dda5c1269d742a0223b8/Example/EditorDemo/WPViewController.m#L303-L308))
- Editor Demo: Action sheet that appears when tapping an uploading video
- Editor Demo: Action sheet that appears when tapping an image that failed uploading (see [here](https://github.com/wordpress-mobile/WordPress-Editor-iOS/blob/ff1adff26ed5c6624278dda5c1269d742a0223b8/Example/EditorDemo/WPViewController.m#L319-L324))

/cc @diegoreymendez 


