### PR TITLE
Expose a way to make visible or hidden a toolbar item

### DIFF
--- a/Classes/WPEditorFormatbarView.h
+++ b/Classes/WPEditorFormatbarView.h
@@ -140,6 +140,14 @@ typedef enum
 #pragma mark - Toolbar items
 
 /**
+ *  @brief      Makes a toolbar item visible or hidden
+ *
+ *  @param      tag     WPEditorViewControllerElementTag of the item to alter.
+ *  @param      visible YES to make the item visible, NO to hide it.
+ */
+- (void)toolBarItemWithTag:(WPEditorViewControllerElementTag)tag setVisible:(BOOL)visible;
+
+/**
  *  @brief      Enables and disables the toolbar items.
  *
  *  @param      enable       YES to enable the toolbar buttons; NO to disable them.

--- a/Classes/WPEditorFormatbarView.m
+++ b/Classes/WPEditorFormatbarView.m
@@ -189,6 +189,21 @@
 
 #pragma mark - Toolbar items
 
+- (void)toolBarItemWithTag:(WPEditorViewControllerElementTag)tag setVisible:(BOOL)visible
+{
+    for (ZSSBarButtonItem *item in self.leftToolbar.items) {
+        if (item.tag == tag) {
+            item.customView.hidden = !visible;
+        }
+    }
+
+    for (ZSSBarButtonItem *item in self.regularToolbar.items) {
+        if (item.tag == tag) {
+            item.customView.hidden = !visible;
+        }
+    }
+}
+
 - (void)enableToolbarItems:(BOOL)enable
     shouldShowSourceButton:(BOOL)showSource
 {


### PR DESCRIPTION
refs #4427 - In order to be able to hide the “Insert image” button when a WordPress user doesn’t have the upload_files capabilities, I need to be able to set the hidden property of the toolbar button item.
Because of the specifics of the implementation of WPEditorFormatbarView, rather than exposing a UIBarButtonItem* property to be consumed directly by the app, it’s better to provide a helper method that will, similarly to -enableToolbarItem:showSourceButton:, do the work under the hood of the editor itself.