### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ platform :ios, '9.0'
 pod 'WordPress-iOS-Editor'
 ```
 
-Or, you can just try out the demo by using the Cocoapods try command:
+Or, you can just try out the demo by using the CocoaPods try command:
 
 ```ruby
 pod try WordPress-iOS-Editor
@@ -33,7 +33,7 @@ WordPress-iOS-Editor requires iOS 9.0 or higher. It depends on the following App
 * CoreGraphics.framework
 * CoreText.framework
 
-and the following Cocoapods:
+and the following CocoaPods:
 
 * [CocoaLumberjack](https://github.com/CocoaLumberjack/CocoaLumberjack)
 * [WordPress-iOS-Shared](https://github.com/wordpress-mobile/WordPress-iOS-Shared)


### PR DESCRIPTION

This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>
<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>

Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
