### PR TITLE
Make strings localizable

### DIFF
--- a/Assets/ZSSRichTextEditor.js
+++ b/Assets/ZSSRichTextEditor.js
@@ -54,6 +54,10 @@ ZSSEditor.lastTappedNode = null;
 // The default paragraph separator
 ZSSEditor.defaultParagraphSeparator = 'p';
 
+// Localization strings
+ZSSEditor.localizedEditLabel = "Edit";
+ZSSEditor.localizedTapToTryAgainLabel = "Tap to try again!";
+
 /**
  * The initializer function that must be called onLoad
  */
@@ -759,7 +763,7 @@ ZSSEditor.insertLocalImage = function(imageNodeIdentifier, localImageUrl) {
     var space = '&nbsp';
     var progressIdentifier = this.getImageProgressIdentifier(imageNodeIdentifier);
     var imageContainerIdentifier = this.getImageContainerIdentifier(imageNodeIdentifier);
-    var imgContainerStart = '<span id="' + imageContainerIdentifier+'" class="img_container" contenteditable="false" data-failed="Tap to try again!">';
+    var imgContainerStart = '<span id="' + imageContainerIdentifier+'" class="img_container" contenteditable="false" data-failed="' + this.localizedtapToTryAgainLabel + '">';
     var imgContainerEnd = '</span>';
     var progress = '<progress id="' + progressIdentifier+'" value=0  class="wp_media_indicator"  contenteditable="false"></progress>';
     var image = '<img data-wpid="' + imageNodeIdentifier + '" src="' + localImageUrl + '" alt="" />';
@@ -1368,7 +1372,7 @@ ZSSEditor.applyImageSelectionFormatting = function( imageNode ) {
         sizeClass = " small";
     }
 
-    var overlay = '<span class="edit-overlay"><span class="edit-content">Edit</span></span>';
+    var overlay = '<span class="edit-overlay"><span class="edit-content">' + this.localizedEditLabel + '</span></span>';
     var html = '<span class="edit-container' + sizeClass + '">' + overlay + '</span>';
    	node.insertAdjacentHTML( 'beforebegin', html );
     var selectionNode = node.previousSibling;

--- a/Assets/ZSSRichTextEditor.js
+++ b/Assets/ZSSRichTextEditor.js
@@ -55,8 +55,8 @@ ZSSEditor.lastTappedNode = null;
 ZSSEditor.defaultParagraphSeparator = 'p';
 
 // Localization strings
-ZSSEditor.localizedEditLabel = "Edit";
-ZSSEditor.localizedTapToTryAgainLabel = "Tap to try again!";
+ZSSEditor.localizedEditText = "Edit";
+ZSSEditor.localizedTapToTryAgainText = "Tap to try again!";
 
 /**
  * The initializer function that must be called onLoad
@@ -763,7 +763,7 @@ ZSSEditor.insertLocalImage = function(imageNodeIdentifier, localImageUrl) {
     var space = '&nbsp';
     var progressIdentifier = this.getImageProgressIdentifier(imageNodeIdentifier);
     var imageContainerIdentifier = this.getImageContainerIdentifier(imageNodeIdentifier);
-    var imgContainerStart = '<span id="' + imageContainerIdentifier+'" class="img_container" contenteditable="false" data-failed="' + this.localizedtapToTryAgainLabel + '">';
+    var imgContainerStart = '<span id="' + imageContainerIdentifier+'" class="img_container" contenteditable="false" data-failed="' + this.localizedTapToTryAgainText + '">';
     var imgContainerEnd = '</span>';
     var progress = '<progress id="' + progressIdentifier+'" value=0  class="wp_media_indicator"  contenteditable="false"></progress>';
     var image = '<img data-wpid="' + imageNodeIdentifier + '" src="' + localImageUrl + '" alt="" />';
@@ -1372,7 +1372,7 @@ ZSSEditor.applyImageSelectionFormatting = function( imageNode ) {
         sizeClass = " small";
     }
 
-    var overlay = '<span class="edit-overlay"><span class="edit-content">' + this.localizedEditLabel + '</span></span>';
+    var overlay = '<span class="edit-overlay"><span class="edit-content">' + this.localizedEditText + '</span></span>';
     var html = '<span class="edit-container' + sizeClass + '">' + overlay + '</span>';
    	node.insertAdjacentHTML( 'beforebegin', html );
     var selectionNode = node.previousSibling;

--- a/Assets/ZSSRichTextEditor.js
+++ b/Assets/ZSSRichTextEditor.js
@@ -56,7 +56,6 @@ ZSSEditor.defaultParagraphSeparator = 'p';
 
 // Localization strings
 ZSSEditor.localizedEditText = "Edit";
-ZSSEditor.localizedTapToTryAgainText = "Tap to try again!";
 
 /**
  * The initializer function that must be called onLoad
@@ -763,7 +762,7 @@ ZSSEditor.insertLocalImage = function(imageNodeIdentifier, localImageUrl) {
     var space = '&nbsp';
     var progressIdentifier = this.getImageProgressIdentifier(imageNodeIdentifier);
     var imageContainerIdentifier = this.getImageContainerIdentifier(imageNodeIdentifier);
-    var imgContainerStart = '<span id="' + imageContainerIdentifier+'" class="img_container" contenteditable="false" data-failed="' + this.localizedTapToTryAgainText + '">';
+    var imgContainerStart = '<span id="' + imageContainerIdentifier+'" class="img_container" contenteditable="false">';
     var imgContainerEnd = '</span>';
     var progress = '<progress id="' + progressIdentifier+'" value=0  class="wp_media_indicator"  contenteditable="false"></progress>';
     var image = '<img data-wpid="' + imageNodeIdentifier + '" src="' + localImageUrl + '" alt="" />';

--- a/Classes/WPEditorView.h
+++ b/Classes/WPEditorView.h
@@ -312,6 +312,23 @@ stylesForCurrentSelection:(NSArray*)styles;
 
 - (void)removeImage:(NSString*)uniqueId;
 
+#pragma mark - Localization
+
+/**
+ *	@brief		Sets the text for the edit button on images.  Useful for localization.
+ *
+ *	@param		text		The text to use.  Cannot be nil.
+ */
+- (void)setImageEditText:(NSString *)text;
+
+/**
+ *	@brief		Sets the text for the try again text for failed image uploads.  Useful for
+ *				localization.
+ *
+ *	@param		text		The text to use.  Cannot be nil.
+ */
+- (void)setImageTryAgainUploadText:(NSString *)text;
+
 #pragma mark - Videos
 
 /**

--- a/Classes/WPEditorView.h
+++ b/Classes/WPEditorView.h
@@ -321,14 +321,6 @@ stylesForCurrentSelection:(NSArray*)styles;
  */
 - (void)setImageEditText:(NSString *)text;
 
-/**
- *	@brief		Sets the text for the try again text for failed image uploads.  Useful for
- *				localization.
- *
- *	@param		text		The text to use.  Cannot be nil.
- */
-- (void)setImageTryAgainUploadText:(NSString *)text;
-
 #pragma mark - Videos
 
 /**

--- a/Classes/WPEditorView.m
+++ b/Classes/WPEditorView.m
@@ -1596,14 +1596,6 @@ shouldStartLoadWithRequest:(NSURLRequest *)request
 	[self.webView stringByEvaluatingJavaScriptFromString:trigger];
 }
 
-- (void)setImageTryAgainUploadText:(NSString *)text
-{
-	NSParameterAssert([text isKindOfClass:[NSString class]]);
-	
-	NSString *trigger = [NSString stringWithFormat:@"ZSSEditor.localizedTapToTryAgainText = \"%@\"", text];
-	[self.webView stringByEvaluatingJavaScriptFromString:trigger];
-}
-
 #pragma mark - URL normalization
 
 - (NSString*)normalizeURL:(NSString*)url

--- a/Classes/WPEditorView.m
+++ b/Classes/WPEditorView.m
@@ -1588,19 +1588,19 @@ shouldStartLoadWithRequest:(NSURLRequest *)request
 
 #pragma mark - Localization
 
-- (void)setImageEditLabel:(NSString *)label
+- (void)setImageEditText:(NSString *)text
 {
-	NSParameterAssert([label isKindOfClass:[NSString class]]);
+	NSParameterAssert([text isKindOfClass:[NSString class]]);
 	
-	NSString *trigger = [NSString stringWithFormat:@"ZSSEditor.localizedEditLabel = \"%@\"", label];
+	NSString *trigger = [NSString stringWithFormat:@"ZSSEditor.localizedEditText = \"%@\"", text];
 	[self.webView stringByEvaluatingJavaScriptFromString:trigger];
 }
 
-- (void)setImageTryAgainUploadLabel:(NSString *)label
+- (void)setImageTryAgainUploadText:(NSString *)text
 {
-	NSParameterAssert([label isKindOfClass:[NSString class]]);
+	NSParameterAssert([text isKindOfClass:[NSString class]]);
 	
-	NSString *trigger = [NSString stringWithFormat:@"ZSSEditor.localizedTapToTryAgainLabel = \"%@\"", label];
+	NSString *trigger = [NSString stringWithFormat:@"ZSSEditor.localizedTapToTryAgainText = \"%@\"", text];
 	[self.webView stringByEvaluatingJavaScriptFromString:trigger];
 }
 

--- a/Classes/WPEditorView.m
+++ b/Classes/WPEditorView.m
@@ -1586,6 +1586,24 @@ shouldStartLoadWithRequest:(NSURLRequest *)request
     [self.webView stringByEvaluatingJavaScriptFromString:trigger];
 }
 
+#pragma mark - Localization
+
+- (void)setImageEditLabel:(NSString *)label
+{
+	NSParameterAssert([label isKindOfClass:[NSString class]]);
+	
+	NSString *trigger = [NSString stringWithFormat:@"ZSSEditor.localizedEditLabel = \"%@\"", label];
+	[self.webView stringByEvaluatingJavaScriptFromString:trigger];
+}
+
+- (void)setImageTryAgainUploadLabel:(NSString *)label
+{
+	NSParameterAssert([label isKindOfClass:[NSString class]]);
+	
+	NSString *trigger = [NSString stringWithFormat:@"ZSSEditor.localizedTapToTryAgainLabel = \"%@\"", label];
+	[self.webView stringByEvaluatingJavaScriptFromString:trigger];
+}
+
 #pragma mark - URL normalization
 
 - (NSString*)normalizeURL:(NSString*)url


### PR DESCRIPTION
Fixes #756.

**Test 1:**
1. Use the editor normally, and make sure the "Edit" and "Try again" messages show up as usual.

**Test 2:**
1. Test the same thing using WPiOS branch `editor/756-hard-coded-strings-in-editor`.

/cc @SergioEstevao for review.