### PR TITLE
Links inserted from scratch leave the selection at the end of the link.

### DIFF
--- a/Assets/ZSSRichTextEditor.js
+++ b/Assets/ZSSRichTextEditor.js
@@ -547,18 +547,14 @@ ZSSEditor.insertLink = function(url, title) {
 	if (sel.rangeCount) {
 		var range = sel.getRangeAt(0).cloneRange();
 		
-		var isEmptyRange = (range.startNode == range.endNode && range.startOffset == range.endOffset);
-		
 		var el = document.createElement("a");
 		el.setAttribute("href", url);
 		
 		range.surroundContents(el);
 		el.innerHTML = title;
 		
-		if (isEmptyRange) {
-			range.setStartAfter(el);
-			range.setEndAfter(el);
-		}
+		range.setStartAfter(el);
+		range.setEndAfter(el);
 		
 		sel.removeAllRanges();
 		sel.addRange(range);

--- a/Assets/ZSSRichTextEditor.js
+++ b/Assets/ZSSRichTextEditor.js
@@ -542,16 +542,24 @@ ZSSEditor.setBackgroundColor = function(color) {
 ZSSEditor.insertLink = function(url, title) {
 
     ZSSEditor.restoreRange();
-	
+
     var sel = document.getSelection();
 	if (sel.rangeCount) {
-
+		var range = sel.getRangeAt(0).cloneRange();
+		
+		var isEmptyRange = (range.startNode == range.endNode && range.startOffset == range.endOffset);
+		
 		var el = document.createElement("a");
 		el.setAttribute("href", url);
 		
-		var range = sel.getRangeAt(0).cloneRange();
 		range.surroundContents(el);
 		el.innerHTML = title;
+		
+		if (isEmptyRange) {
+			range.setStartAfter(el);
+			range.setEndAfter(el);
+		}
+		
 		sel.removeAllRanges();
 		sel.addRange(range);
 	}


### PR DESCRIPTION
Fixes #722.

**Test 1:**
1. Launch the demo app.
2. Start writing
3. Insert a link from scratch.
4. After inserting the link the selection should be placed at the end of the link.

**Test 2:**
1. Launch the demo app.
2. Select an existing word to add a link to it.
3. Insert a link.
4. After inserting the link the selection should still be surrounding the full word.

/cc @bummytime 
