### PR TITLE
Fixed cursor in title in HTML mode (for issue #714).

### DIFF
--- a/Classes/WPEditorView.m
+++ b/Classes/WPEditorView.m
@@ -224,10 +224,10 @@ static NSString* const WPEditorViewWebViewContentSizeKey = @"contentSize";
 
 - (void)startObservingTitleFieldChanges
 {
-	[[NSNotificationCenter defaultCenter] addObserver:self
-											 selector:@selector(titleTextDidChange)
-												 name:UITextFieldTextDidChangeNotification
-											   object:nil];
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(titleTextDidChange)
+                                                 name:UITextFieldTextDidChangeNotification
+                                               object:nil];
 }
 
 - (void)startObservingWebViewContentSizeChanges

--- a/Classes/WPEditorView.m
+++ b/Classes/WPEditorView.m
@@ -66,6 +66,7 @@ static NSString* const WPEditorViewWebViewContentSizeKey = @"contentSize";
 - (void)dealloc
 {
     [self stopObservingKeyboardNotifications];
+	[self stopObservingTitleFieldChanges];
     [self stopObservingWebViewContentSizeChanges];
 }
 
@@ -122,6 +123,7 @@ static NSString* const WPEditorViewWebViewContentSizeKey = @"contentSize";
     _sourceViewTitleField.accessibilityLabel = NSLocalizedString(@"Title", @"Post title");
     _sourceViewTitleField.returnKeyType = UIReturnKeyNext;
     [self addSubview:_sourceViewTitleField];
+	[self startObservingTitleFieldChanges];
 }
 
 - (void)createSourceDividerViewWithFrame:(CGRect)frame
@@ -217,7 +219,15 @@ static NSString* const WPEditorViewWebViewContentSizeKey = @"contentSize";
                 });
             }
         }
-    }
+	}
+}
+
+- (void)startObservingTitleFieldChanges
+{
+	[[NSNotificationCenter defaultCenter] addObserver:self
+											 selector:@selector(titleTextDidChange)
+												 name:UITextFieldTextDidChangeNotification
+											   object:nil];
 }
 
 - (void)startObservingWebViewContentSizeChanges
@@ -226,6 +236,12 @@ static NSString* const WPEditorViewWebViewContentSizeKey = @"contentSize";
                           forKeyPath:WPEditorViewWebViewContentSizeKey
                              options:NSKeyValueObservingOptionNew
                              context:nil];
+}
+
+- (void)stopObservingTitleFieldChanges
+{
+	[[NSNotificationCenter defaultCenter] removeObserver:self
+											  forKeyPath:UITextFieldTextDidChangeNotification];
 }
 
 - (void)stopObservingWebViewContentSizeChanges
@@ -1993,17 +2009,17 @@ shouldStartLoadWithRequest:(NSURLRequest *)request
     return YES;
 }
 
-- (BOOL)textField:(UITextField *)textField shouldChangeCharactersInRange:(NSRange)range replacementString:(NSString *)string
-{
-    textField.text = [textField.text stringByReplacingCharactersInRange:range withString:string];
-    [self callDelegateEditorTitleDidChange];
-    return NO;
-}
-
 - (BOOL)textFieldShouldReturn:(UITextField *)textField
 {
     [self.sourceView becomeFirstResponder];
     return NO;
+}
+
+#pragma mark - UITextField: event handlers
+
+- (void)titleTextDidChange
+{
+	[self callDelegateEditorTitleDidChange];
 }
 
 #pragma mark - Delegate calls

--- a/Classes/WPEditorView.m
+++ b/Classes/WPEditorView.m
@@ -65,8 +65,7 @@ static NSString* const WPEditorViewWebViewContentSizeKey = @"contentSize";
 
 - (void)dealloc
 {
-    [self stopObservingKeyboardNotifications];
-	[self stopObservingTitleFieldChanges];
+	[[NSNotificationCenter defaultCenter] removeObserver:self];
     [self stopObservingWebViewContentSizeChanges];
 }
 
@@ -98,9 +97,10 @@ static NSString* const WPEditorViewWebViewContentSizeKey = @"contentSize";
 - (void)willMoveToSuperview:(UIView *)newSuperview
 {
     if (!newSuperview) {
-        [self stopObservingKeyboardNotifications];
+		[[NSNotificationCenter defaultCenter] removeObserver:self];
     } else {
         [self startObservingKeyboardNotifications];
+		[self startObservingTitleFieldChanges];
     }
 }
 
@@ -238,12 +238,6 @@ static NSString* const WPEditorViewWebViewContentSizeKey = @"contentSize";
                              context:nil];
 }
 
-- (void)stopObservingTitleFieldChanges
-{
-	[[NSNotificationCenter defaultCenter] removeObserver:self
-											  forKeyPath:UITextFieldTextDidChangeNotification];
-}
-
 - (void)stopObservingWebViewContentSizeChanges
 {
     [self.webView.scrollView removeObserver:self
@@ -299,13 +293,6 @@ static NSString* const WPEditorViewWebViewContentSizeKey = @"contentSize";
                                              selector:@selector(keyboardWillHide:)
                                                  name:UIKeyboardWillHideNotification
                                                object:nil];
-}
-
-- (void)stopObservingKeyboardNotifications
-{
-    [[NSNotificationCenter defaultCenter] removeObserver:self name:UIKeyboardDidShowNotification object:nil];
-    [[NSNotificationCenter defaultCenter] removeObserver:self name:UIKeyboardWillShowNotification object:nil];
-    [[NSNotificationCenter defaultCenter] removeObserver:self name:UIKeyboardWillHideNotification object:nil];
 }
 
 #pragma mark - Keyboard status


### PR DESCRIPTION
Fixes #714.

**Test 1:**
1. Launch the demo app.
2. Switch to HTML mode.
3. Edit the title right moving the caret around, and make sure the caret doesn't jump to the end.

**Test 2:**
1. Using WPiOS branch `editor/714-cursor-jumping-to-end`.
2. Launch WPiOS.
3. Create or edit a post.
4. Switch to HTML mode.
5. Edit the title and make sure the caret's position doesn't move to the end.
6. Make sure whatever changes you make to the title are properly saved.

/cc @SergioEstevao for review.