### PR TITLE
Fix java script errors when no focused field

### DIFF
--- a/Assets/ZSSRichTextEditor.js
+++ b/Assets/ZSSRichTextEditor.js
@@ -1851,7 +1851,7 @@ ZSSEditor.sendEnabledStyles = function(e) {
 	
     var focusedField = this.getFocusedField();
     
-    if (!focusedField.hasNoStyle) {
+    if (focusedField && !focusedField.hasNoStyle) {
         // Find all relevant parent tags
         var parentTags = ZSSEditor.parentTags();
         

--- a/Assets/ZSSRichTextEditor.js
+++ b/Assets/ZSSRichTextEditor.js
@@ -234,10 +234,11 @@ ZSSEditor.getCaretArguments = function() {
 ZSSEditor.getJoinedFocusedFieldIdAndCaretArguments = function() {
     
     var joinedArguments = ZSSEditor.getJoinedCaretArguments();
-    var idArgument = "id=" + ZSSEditor.getFocusedField().getNodeId();
-    
-    joinedArguments = idArgument + defaultCallbackSeparator + joinedArguments;
-    
+    var focusedField = ZSSEditor.getFocusedField();
+    if (focusedField) {
+        var idArgument = "id=" + focusedField.getNodeId();
+        joinedArguments = idArgument + defaultCallbackSeparator + joinedArguments;
+    }
     return joinedArguments;
 };
 

--- a/Assets/ZSSRichTextEditor.js
+++ b/Assets/ZSSRichTextEditor.js
@@ -193,9 +193,14 @@ ZSSEditor.getFocusedField = function() {
     
     while (currentField
            && (!currentFieldId || this.editableFields[currentFieldId] == null)) {
-        currentField = this.closerParentNodeStartingAtNode('div', currentField);
-        currentFieldId = currentField.attr('id');
-        
+
+        var newField = this.closerParentNodeStartingAtNode('div', currentField);
+        if (newField) {
+            currentField = newField;
+            currentFieldId = currentField.attr('id');
+        } else {
+            currentField = newField;
+        }
     }
     
     return this.editableFields[currentFieldId];


### PR DESCRIPTION
How to test:

Test 1:
 - Insert an image on the content
 - While the progress bar is going click on the Edit button on the top left, in order to take focus out of the editor
 - Wait for the progress bar finish and see if no error shows up in the console

Test 2:
 - Use the editor multiple format selections on the text and see if they all behave and the toolbar gets updated with the correct states.

Needs Review: @diegoreymendez