### PR TITLE
Fix for HTML mode switching hack

### DIFF
--- a/Classes/WPEditorViewController.m
+++ b/Classes/WPEditorViewController.m
@@ -1065,8 +1065,11 @@ didFailLoadWithError:(NSError *)error
     // This hack forces the input accessory view to refresh itself and resize properly.
     if (self.isFirstSetupComplete) {
         if ([self.editorView isInVisualMode]) {
-            [[self.editorView focusedField] blur];
-            [[self.editorView focusedField] focus];
+            WPEditorField *field = [self.editorView focusedField];
+            [self.editorView saveSelection];
+            [field blur];
+            [field focus];
+            [self.editorView restoreSelection];
         } else {
             if ([[self.editorView sourceViewTitleField] isFirstResponder]) {
                 [[self.editorView sourceViewTitleField] resignFirstResponder];

--- a/Classes/WPEditorViewController.m
+++ b/Classes/WPEditorViewController.m
@@ -1062,18 +1062,19 @@ didFailLoadWithError:(NSError *)error
 
 - (void)recoverFromViewSizeChange
 {
+    // This hack forces the input accessory view to refresh itself and resize properly.
     if (self.isFirstSetupComplete) {
-        // Important: This is a complete and utter hack that compensates for the input accessory view
-        // not properly changing size classes (resizing) when the rest of the views in the editor VC do.
-        // Toggling the HTML button on the input bar quickly does not affect the view and forces the
-        // input accessory view (the format bar) to update itself. FWIW, setNeedsDisplay and
-        // setNeedsLayout do NOT work.
         if ([self.editorView isInVisualMode]) {
-            [self.editorView showHTMLSource];
-            [self.editorView showVisualEditor];
+            [[self.editorView focusedField] blur];
+            [[self.editorView focusedField] focus];
         } else {
-            [self.editorView showHTMLSource];
-            [self.editorView showVisualEditor];
+            if ([[self.editorView sourceViewTitleField] isFirstResponder]) {
+                [[self.editorView sourceViewTitleField] resignFirstResponder];
+                [[self.editorView sourceViewTitleField] becomeFirstResponder];
+            } else {
+                [[self.editorView sourceView] resignFirstResponder];
+                [[self.editorView sourceView] becomeFirstResponder];
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes #777 

Updates the hack that was originally used to fix an issue where the format bar would not resize properly when the editor was rotated or resized. Now, instead of switching modes, we blur and refocus the field which updates the input accessory view and forces it to resize properly. Doing this allows media to upload without being interrupted.

Things to test:

* Run the app on an Air2 or iPad Pro. Use multitasking in various ways...make sure the format bar resizes. Upload media while doing this and make sure it is not interrupted.
* Run the app various iPhones....make sure the format bar resizes. Upload media while doing this and make sure it is not interrupted.
* Upload media while rotating the device.

/cc @SergioEstevao 