### PR TITLE
Add ability to paste images

### DIFF
--- a/Assets/ZSSRichTextEditor.js
+++ b/Assets/ZSSRichTextEditor.js
@@ -107,7 +107,12 @@ ZSSEditor.init = function(callbacker, logger) {
         // Ensure we only insert plaintext from the pasteboard
         e.preventDefault();
         var plainText = (e.originalEvent || e).clipboardData.getData('text/plain');
-        document.execCommand('insertText', false, plainText);
+        if (plainText.length > 0) {
+            document.execCommand('insertText', false, plainText);
+        } else {
+            //var joinedArguments = ZSSEditor.getJoinedFocusedFieldIdAndCaretArguments();
+            ZSSEditor.callback("callback-paste");
+        }
     });
 
     this.domLoadedCallback();

--- a/Classes/WPEditorView.h
+++ b/Classes/WPEditorView.h
@@ -1,6 +1,7 @@
 #import <UIKit/UIKit.h>
 
 #import "ZSSTextView.h"
+//#import "WPViewController.h" // TODO: find a better way
 
 @class WPEditorView;
 @class WPEditorField;
@@ -113,7 +114,7 @@
          imageMeta:(WPImageMeta *)imageMeta;
 
 /**
- * @brief		Received when the user taps on a image in the editor.
+ * @brief		Received when the user taps on a video in the editor.
  *
  * @param		editorView	The editor view.
  * @param		videoId		The id of image of the image that was tapped.

--- a/Classes/WPEditorView.h
+++ b/Classes/WPEditorView.h
@@ -157,8 +157,8 @@ stylesForCurrentSelection:(NSArray*)styles;
 /**
  * @brief		Received when an image is pasted into the editor.
  *
- * @param		editorView	The editor view.
- * @param		imageId		The id of image of the image that was pasted.
+ * @param       editorView  The editor view.
+ * @param       imageId     The id of image of the image that was pasted.
  *
  */
 - (void)editorView:(WPEditorView*)editorView

--- a/Classes/WPEditorView.h
+++ b/Classes/WPEditorView.h
@@ -1,7 +1,6 @@
 #import <UIKit/UIKit.h>
 
 #import "ZSSTextView.h"
-//#import "WPViewController.h" // TODO: find a better way
 
 @class WPEditorView;
 @class WPEditorField;
@@ -154,6 +153,16 @@ stylesForCurrentSelection:(NSArray*)styles;
  */
 - (void)editorView:(WPEditorView*)editorView
      videoReplaced:(NSString *)videoID;
+
+/**
+ * @brief		Received when an image is pasted into the editor.
+ *
+ * @param		editorView	The editor view.
+ * @param		imageId		The id of image of the image that was pasted.
+ *
+ */
+- (void)editorView:(WPEditorView*)editorView
+     imagePasted:(UIImage *)image;
 
 /**
  * @brief		Received when a the editor request the url for a videopress shortcode.

--- a/Classes/WPEditorView.m
+++ b/Classes/WPEditorView.m
@@ -946,12 +946,11 @@ shouldStartLoadWithRequest:(NSURLRequest *)request
     
     if (pasteboard.image != nil) {
         UIImage *pastedImage = pasteboard.image;
-        NSString *imageID = [[NSUUID UUID] UUIDString];
-        NSString *path = [NSString stringWithFormat:@"%@/%@.jpg", NSTemporaryDirectory(), imageID];
-        NSData *imageData = UIImagePNGRepresentation(pastedImage);
-        [imageData writeToFile:path atomically:YES];
         
-        [self insertLocalImage:[[NSURL fileURLWithPath:path] absoluteString] uniqueId:imageID];
+        if ([self.delegate respondsToSelector:@selector(editorView:imagePasted:)])
+        {
+            [self.delegate editorView:self imagePasted:pastedImage];
+        }
     }
 }
 

--- a/Classes/WPEditorViewController.h
+++ b/Classes/WPEditorViewController.h
@@ -100,6 +100,16 @@ WPEditorViewControllerMode;
                videoReplaced:(NSString *)videoID;
 
 /**
+ * @brief		Received when an image is pasted into the editor.
+ *
+ * @param		editorViewController    The editor view controller.
+ * @param		imageId                 The id of image of the image that was pasted.
+ *
+ */
+- (void)editorViewController:(WPEditorViewController*)editorViewController
+               imagePasted:(UIImage *)image;
+
+/**
  *	@brief		Received when the editor requests information about a videopress video.
  *
  *	@param		editorView	The editor view.

--- a/Classes/WPEditorViewController.m
+++ b/Classes/WPEditorViewController.m
@@ -1021,6 +1021,13 @@ NSInteger const WPLinkAlertViewTag = 92;
 	[self.toolbarView selectToolbarItemsForStyles:styles];
 }
 
+- (void)editorView:(WPEditorView *)editorView imagePasted:(UIImage *)image
+{
+    if ([self.delegate respondsToSelector:@selector(editorViewController:imagePasted:)]) {
+        [self.delegate editorViewController:self imagePasted:image];
+    }
+}
+
 
 #ifdef DEBUG
 -      (void)webView:(UIWebView *)webView

--- a/Example/EditorDemo/WPViewController.m
+++ b/Example/EditorDemo/WPViewController.m
@@ -123,6 +123,31 @@
     [self.mediaAdded removeObjectForKey:imageId];
 }
 
+- (void)editorViewController:(WPEditorViewController *)editorViewController imagePasted:(UIImage *)image
+{
+    NSString *imageID = [[NSUUID UUID] UUIDString];
+    NSString *path = [NSString stringWithFormat:@"%@/%@.jpg", NSTemporaryDirectory(), imageID];
+    NSData *imageData = UIImagePNGRepresentation(image);
+    [imageData writeToFile:path atomically:YES];
+
+    [self.editorView insertLocalImage:[[NSURL fileURLWithPath:path] absoluteString] uniqueId:imageID];
+
+    NSProgress *progress = [[NSProgress alloc] initWithParent:nil userInfo:@{ @"imageID": imageID, @"url": path }];
+    progress.cancellable = YES;
+    progress.totalUnitCount = 100;
+    NSTimer * timer = [NSTimer scheduledTimerWithTimeInterval:0.1
+                                                       target:self
+                                                     selector:@selector(timerFireMethod:)
+                                                     userInfo:progress
+                                                      repeats:YES];
+    [progress setCancellationHandler:^{
+        [timer invalidate];
+    }];
+
+    self.mediaAdded[imageID] = progress;
+    
+}
+
 - (void)editorViewController:(WPEditorViewController *)editorViewController videoReplaced:(NSString *)videoId
 {
     [self.mediaAdded removeObjectForKey:videoId];


### PR DESCRIPTION
This begins to address #655 by allowing images on the clipboard to be pasted into the editor. It's also the first step for https://github.com/wordpress-mobile/WordPress-iOS/issues/4815 (the second step being adding support to WP-iOS itself).

The general design is: if the paste results in an empty string in the JS, use the callback to have native code access the pasteboard. If this design is acceptable, it can be expanded in the future to add support for videos, multiple images, or a mix of text, images, and video.

/cc @SergioEstevao @diegoreymendez 

Thanks, and let me know what you think. 