### PR TITLE
Fixes an issue with the backspace key.

### DIFF
--- a/Assets/ZSSRichTextEditor.js
+++ b/Assets/ZSSRichTextEditor.js
@@ -2446,6 +2446,16 @@ ZSSField.prototype.handleFocusEvent = function(e) {
 
 ZSSField.prototype.handleKeyDownEvent = function(e) {
     
+    var wasBackspaceOrDeletePressed = (e.keyCode == 8 || e.keyCode == 46);
+    
+    // We don't want to alter the default behaviour for the backspace and delete key.
+    //
+    // Ref: https://github.com/wordpress-mobile/WordPress-Editor-iOS/issues/803
+    //
+    if (wasBackspaceOrDeletePressed) {
+        return;
+    }
+    
     var wasEnterPressed = (e.keyCode == '13');
     
     if (this.isComposing) {


### PR DESCRIPTION
Fixes #803.

How to test:
1. Check out WPiOS branch `editor/803-backspace-issues`.
2. Run the app.
3. Create a post.
4. While in visual mode, paste [this](http://d.pr/n/1fwA6) into the content field.
5. Make sure backspacing and deleting text works normally.

A video showing the issue can be seen [here](https://twitter.com/chartier/status/719904887119544320).