### PR TITLE
Fixes an issue with rangy's markers.

### DIFF
--- a/Assets/ZSSRichTextEditor.js
+++ b/Assets/ZSSRichTextEditor.js
@@ -222,7 +222,9 @@ ZSSEditor.backupRange = function(){
         
         if (text.length > 0) {
             this.savedSelection = rangy.saveSelection()
+            this.savedFocusedField = null;
         } else {
+            this.savedSelection = null;
             this.savedFocusedField = focusedField;
         }
     }
@@ -231,6 +233,7 @@ ZSSEditor.backupRange = function(){
 ZSSEditor.restoreRange = function(){
     if (this.savedSelection) {
 		rangy.restoreSelection(this.savedSelection);
+        this.savedSelection = null;
     } else if (this.savedFocusedField != null) {
         this.savedFocusedField.focus();
         this.savedFocusedField = null;

--- a/Assets/ZSSRichTextEditor.js
+++ b/Assets/ZSSRichTextEditor.js
@@ -43,6 +43,7 @@ ZSSEditor.currentEditingVideo;
 ZSSEditor.currentEditingLink;
 
 ZSSEditor.focusedField = null;
+ZSSEditor.savedFocusedField = null;
 
 // The objects that are enabled
 ZSSEditor.enabledItems = {};
@@ -217,10 +218,12 @@ ZSSEditor.backupRange = function(){
     var focusedField = this.getFocusedField();
     
     if (focusedField) {
-        var text = getTextWithoutNbspOrBom();
+        var text = focusedField.getTextWithoutNbspOrBom();
         
         if (text.length > 0) {
             this.savedSelection = rangy.saveSelection()
+        } else {
+            this.savedFocusedField = focusedField;
         }
     }
 };
@@ -228,6 +231,9 @@ ZSSEditor.backupRange = function(){
 ZSSEditor.restoreRange = function(){
     if (this.savedSelection) {
 		rangy.restoreSelection(this.savedSelection);
+    } else if (this.savedFocusedField != null) {
+        this.savedFocusedField.focus();
+        this.savedFocusedField = null;
     }
 };
 

--- a/Assets/ZSSRichTextEditor.js
+++ b/Assets/ZSSRichTextEditor.js
@@ -214,7 +214,15 @@ ZSSEditor.getFocusedField = function() {
 // MARK: - Selection
 
 ZSSEditor.backupRange = function(){
-	this.savedSelection = rangy.saveSelection()
+    var focusedField = this.getFocusedField();
+    
+    if (focusedField) {
+        var text = getTextWithoutNbspOrBom();
+        
+        if (text.length > 0) {
+            this.savedSelection = rangy.saveSelection()
+        }
+    }
 };
 
 ZSSEditor.restoreRange = function(){
@@ -2396,15 +2404,22 @@ ZSSField.prototype.bindMutationObserver = function () {
 
 // MARK: - Emptying the field when it should be, well... empty (HTML madness)
 
+ZSSField.prototype.getTextWithoutNbspOrBom = function() {
+    var nbsp = '\xa0';
+    var bom = '\uFEFF';
+    var text = this.wrappedObject.text().replace(nbsp, '').replace(bom, '');
+    
+    return text;
+}
+
 /**
  *  @brief      Sometimes HTML leaves some <br> tags or &nbsp; when the user deletes all
  *              text from a contentEditable field.  This code makes sure no such 'garbage' survives.
  *  @details    If the node contains child image nodes, then the content is left untouched.
  */
 ZSSField.prototype.emptyFieldIfNoContents = function() {
-
-    var nbsp = '\xa0';
-    var text = this.wrappedObject.text().replace(nbsp, '');
+    
+    var text = this.getTextWithoutNbspOrBom();
     
     if (text.length == 0) {
         

--- a/Example/EditorDemo/WPViewController.m
+++ b/Example/EditorDemo/WPViewController.m
@@ -64,11 +64,6 @@
     }
 }
 
--(void)prepareForSegue:(UIStoryboardSegue *)segue sender:(id)sender {
-    [self.editorView saveSelection];
-    [super prepareForSegue:segue sender:sender];
-}
-
 #pragma mark - IBActions
 
 - (IBAction)exit:(UIStoryboardSegue*)segue


### PR DESCRIPTION
Fixes the issue [reported here](https://github.com/wordpress-mobile/WordPress-Editor-iOS/issues/813), in which posts are showing strange hex characters in their titles.

**How to test:**

Test using this WPiOS branch: `issue/813-weird-characters-in-post-title`

1. Open the editor
2. Make sure the title is focused. If it's not, tap on it.
3. Use the site picker to switch sites
4. Enter a post title
5. Publish post

Make sure the post title doesn't have weird characters in their title... such as in this URL: https://astralimagery.com/2016/05/02/tulips%EF%BB%BF/.