### PR TITLE
Issue/713 Allows pasting URLs from Safari into the visual editor

### DIFF
--- a/Assets/ZSSRichTextEditor.js
+++ b/Assets/ZSSRichTextEditor.js
@@ -105,10 +105,20 @@ ZSSEditor.init = function(callbacker, logger) {
 	}, false);
     
     $('[contenteditable]').on('paste',function(e) {
-        // Ensure we only insert plaintext from the pasteboard
         e.preventDefault();
-        var plainText = (e.originalEvent || e).clipboardData.getData('text/plain');
-        if (plainText.length > 0) {
+
+        var clipboardData = (e.originalEvent || e).clipboardData;
+
+        // If you copy a link from Safari using the share sheet, it's not
+        // available as plain text, only as a URL. So let's first check for
+        // URLs, then plain text.
+        // Fixes https://github.com/wordpress-mobile/WordPress-Editor-iOS/issues/713
+        var url = clipboardData.getData('text/uri-list');
+        var plainText = clipboardData.getData('text/plain');
+
+        if (url.length > 0) {
+          document.execCommand('insertText', false, url);
+        } else if (plainText.length > 0) {
             document.execCommand('insertText', false, plainText);
         } else {
             //var joinedArguments = ZSSEditor.getJoinedFocusedFieldIdAndCaretArguments();


### PR DESCRIPTION
Fixes #713. Links copied from Safari are only available with the `text/uri-list` content type, and we were only checking for `plain/text`. I've updated the paste event handling code to check for links before falling back to plain text.

To Test:

* Visit a web page in mobile Safari, and choose the 'share' action button. Tap "Copy", and then attempt to paste that link into the editor. Without this fix, it would fail silently. With the fix, you should see the link appear.
* Also test copying links from Safari by long pressing on a link and choosing copy.

Needs Review: @SergioEstevao 
(cc @kwonye)