### PR TITLE
Escapes invisible line separator character when inserting HTML

### DIFF
--- a/Classes/WPEditorField.m
+++ b/Classes/WPEditorField.m
@@ -245,7 +245,11 @@ static NSString* const kWPEditorFieldJavascriptTrue = @"true";
     html = [html stringByReplacingOccurrencesOfString:@"\"" withString:@"\\\""];
     html = [html stringByReplacingOccurrencesOfString:@"\r"  withString:@"\\r"];
     html = [html stringByReplacingOccurrencesOfString:@"\n"  withString:@"\\n"];
-    
+
+    // Invisible line separator character.
+    // Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/5496
+    html = [html stringByReplacingOccurrencesOfString:@"\u2028"  withString:@"\\u2028"];
+
     return html;
 }
 


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/5496. 

In WPiOS, the editor fails to display any post content when editing a post that contains in invisible 'line separator' character (unicode 2028: http://www.fileformat.info/info/unicode/char/2028/index.htm). I've fixed this by adding an escape for this character to `-[WPEditorField addSlashes:]`.

### To test:

* Build `develop`, and run the editor demo. Paste this test string into the visual editor:

```
Test Test
```

(there is an invisible line separator between the two Test words)

* Switch to the HTML editor, and then back to the visual editor.
* You should see a JavaScript error in the console like:

```
2016-06-03 10:00:48:951 EditorDemo[6672:1684835] WebEditor error:
  In file: file:///Users/username/Library/Developer/CoreSimulator/Devices/4A2B4BC9-7FB8-4702-82AD-1C0A237045CF/data/Containers/Bundle/Application/F00C0AF5-F616-49F5-88C7-92F161BF95F5/EditorDemo.app/Frameworks/WordPressEditor.framework/editor.html
  In line: 1
  SyntaxError: Unexpected EOF
```

* Now check out this PR's branch and build / run the demo.
* Paste in the same test string.
* Toggle between the HTML and visual editor, and the error should be gone.

This error was occurring in WPiOS when the editor was attempting to load HTML for a post that contained this character. The error would prevent any content from being added to the editor.

Needs Review: @diegoreymendez 