### PR TITLE
Issue/830 Adds an escape for invisible paragraph separators

### DIFF
--- a/Classes/WPEditorField.m
+++ b/Classes/WPEditorField.m
@@ -246,9 +246,11 @@ static NSString* const kWPEditorFieldJavascriptTrue = @"true";
     html = [html stringByReplacingOccurrencesOfString:@"\r"  withString:@"\\r"];
     html = [html stringByReplacingOccurrencesOfString:@"\n"  withString:@"\\n"];
 
-    // Invisible line separator character.
-    // Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/5496
+    // Invisible line separator and paragraph separator characters.
+    // Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/5496 and
+    // https://github.com/wordpress-mobile/WordPress-Editor-iOS/issues/830
     html = [html stringByReplacingOccurrencesOfString:@"\u2028"  withString:@"\\u2028"];
+    html = [html stringByReplacingOccurrencesOfString:@"\u2029"  withString:@"\\u2029"];
 
     return html;
 }


### PR DESCRIPTION
Fixes #830 – Adds another escape for invisible character separators.

See original issue for more info.

To test:

* Paste the following text into the editor, and toggle to the HTML view and back again: 
   `Paragraph Paragraph`
* Without this PR applied, you should see an error in the console similar to `SyntaxError: Unexpected EOF`
* With the PR applied, you should see no error.

Needs review: @diegoreymendez 