### PR TITLE
Simplifies paragraph wrapping

### DIFF
--- a/Assets/ZSSRichTextEditor.js
+++ b/Assets/ZSSRichTextEditor.js
@@ -2740,24 +2740,10 @@ ZSSField.prototype.wrapCaretInParagraphIfNecessary = function()
                                        || closerParentNode.nodeName == NodeName.BLOCKQUOTE);
     
     if (parentNodeShouldBeParagraph) {
-        var selection = window.getSelection();
-        
-        if (selection) {
-            var range = selection.getRangeAt(0);
-            
-            if (range.startContainer == range.endContainer) {
-                var paragraph = document.createElement("p");
-                var textNode = document.createTextNode("&#x200b;");
-                
-                paragraph.appendChild(textNode);
-                
-                range.insertNode(paragraph);
-                range.selectNode(textNode);
-                
-                selection.removeAllRanges();
-                selection.addRange(range);
-            }
-        }
+
+        var savedSelection = rangy.saveSelection();
+        $(closerParentNode).wrapInner("<p>");
+        rangy.restoreSelection(savedSelection);
     }
 };
 


### PR DESCRIPTION
I was still seeing issues with #839. (EDIT: also fixes #842).

The code to wrap the current block of text in a paragraph was quite broken - this patch fixes it.

To test:
Just run the code, paste some text and blockquote it.  Make sure it works right.  Make sure it wraps the contents in a paragraph block.