### PR TITLE
Use the correct identifier for media span container.

### DIFF
--- a/Assets/ZSSRichTextEditor.js
+++ b/Assets/ZSSRichTextEditor.js
@@ -813,7 +813,7 @@ ZSSEditor.insertLocalImage = function(imageNodeIdentifier, localImageUrl) {
             var progressIdentifier = this.getImageProgressIdentifier(imageNodeIdentifier);
 
             var span = document.createElement("span");
-            span.id = imageNodeIdentifier;
+            span.id = this.getImageContainerIdentifier(imageNodeIdentifier);
             span.className = "img_container";
 
             var progress = document.createElement("progress");
@@ -1023,7 +1023,7 @@ ZSSEditor.markImageUploadFailed = function(imageNodeIdentifier, message) {
     }
     
     imageNode.addClass('failed');
-    
+    alert(message);
     var imageContainerNode = this.getImageContainerNodeWithIdentifier(imageNodeIdentifier);
     if(imageContainerNode.length != 0){
         imageContainerNode.attr("data-failed", message);

--- a/Assets/ZSSRichTextEditor.js
+++ b/Assets/ZSSRichTextEditor.js
@@ -1023,7 +1023,6 @@ ZSSEditor.markImageUploadFailed = function(imageNodeIdentifier, message) {
     }
     
     imageNode.addClass('failed');
-    alert(message);
     var imageContainerNode = this.getImageContainerNodeWithIdentifier(imageNodeIdentifier);
     if(imageContainerNode.length != 0){
         imageContainerNode.attr("data-failed", message);


### PR DESCRIPTION
Fixes: #852 

How to test:

 - On the WPViewController class on the demo app, uncomment the lines 437 to 441.
 - Start the demo app
 - Tap on the media add icon
 - Wait for the media to fail
 - Check if error overlay on the image with icon and message shows up correctly.

Test on the iPad also.

Need Review: @diegoreymendez 