### PR TITLE
Improve attribution by adding the license files locally.

### DIFF
--- a/Attribution/CYRTextViewLicense/LICENSE
+++ b/Attribution/CYRTextViewLicense/LICENSE
@@ -1,0 +1,20 @@
+The MIT License (MIT)
+
+Copyright (c) 2014 Cyrillian, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/Attribution/HRColorPickerLicense/LICENSE.txt
+++ b/Attribution/HRColorPickerLicense/LICENSE.txt
@@ -1,0 +1,26 @@
+
+Copyright (c) 2011 Ryota Hayashi  
+All rights reserved.  
+  
+Redistribution and use in source and binary forms, with or without  
+modification, are permitted provided that the following conditions  
+are met:  
+1. Redistributions of source code must retain the above copyright  
+   notice, this list of conditions and the following disclaimer.  
+2. Redistributions in binary form must reproduce the above copyright  
+   notice, this list of conditions and the following disclaimer in the  
+   documentation and/or other materials provided with the distribution.  
+  
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR(S) ``AS IS'' AND ANY EXPRESS OR  
+IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES  
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  
+IN NO EVENT SHALL THE AUTHOR(S) BE LIABLE FOR ANY DIRECT, INDIRECT,  
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT  
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,  
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY  
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT  
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF  
+THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.  
+  
+$FreeBSD$  
+  

--- a/Attribution/ZSSRichTextEditorLicense/LICENSE.txt
+++ b/Attribution/ZSSRichTextEditorLicense/LICENSE.txt
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2014 Zed Said Studio
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Attribution/jsBeautifierLicense/LICENSE.txt
+++ b/Attribution/jsBeautifierLicense/LICENSE.txt
@@ -1,0 +1,9 @@
+The MIT License (MIT)
+
+Copyright (c) 2007-2013 Einar Lielmanis and contributors.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/Classes/WPEditorView.h
+++ b/Classes/WPEditorView.h
@@ -1,3 +1,11 @@
+//
+//  Copyright (c) 2014 Automattic Inc.
+//
+//  This source file is based on ZSSRichTextEditorViewController.h from ZSSRichTextEditor
+//  Created by Nicholas Hubbard on 11/30/13.
+//  Copyright (c) 2013 Zed Said Studio. All rights reserved.
+//
+
 #import <UIKit/UIKit.h>
 
 #import "ZSSTextView.h"

--- a/Classes/WPEditorView.m
+++ b/Classes/WPEditorView.m
@@ -1,3 +1,11 @@
+//
+//  Copyright (c) 2014 Automattic Inc.
+//
+//  This source file is based on ZSSRichTextEditorViewController.m from ZSSRichTextEditor
+//  Created by Nicholas Hubbard on 11/30/13.
+//  Copyright (c) 2013 Zed Said Studio. All rights reserved.
+//
+
 #import "WPEditorView.h"
 
 #import "UIWebView+GUIFixes.h"

--- a/README.md
+++ b/README.md
@@ -90,10 +90,10 @@ The following projects were used in the WordPress-iOS-Editor codebase:
 | Component     | Description   | License  |
 | ------------- |:-------------:| -----:|
 | [ZSSRichTextEditor](https://github.com/nnhubbard/ZSSRichTextEditor)      | ZSSRichTextEditor is a rich text WYSIWYG Editor for iOS and was the basis for this project.| [MIT](Attribution/ZSSRichTextEditorLicense/LICENSE.txt) |
-| [CYRTextView](https://github.com/illyabusigin/CYRTextView)      | CYRTextView is a UITextView subclass that implements a variety of features that are relevant to a syntax or code text view. | [MIT](https://github.com/illyabusigin/CYRTextView/blob/master/LICENSE) |
-| [HRColorPicker](https://github.com/hayashi311/Color-Picker-for-iOS)      | Simple color picker for iPhone      |   [BSD](https://github.com/hayashi311/Color-Picker-for-iOS/blob/master/ColorPicker/HRColorPickerView.h) |
+| [CYRTextView](https://github.com/illyabusigin/CYRTextView)      | CYRTextView is a UITextView subclass that implements a variety of features that are relevant to a syntax or code text view. | [MIT](Attribution/CYRTextViewLicense/LICENSE) |
+| [HRColorPicker](https://github.com/hayashi311/Color-Picker-for-iOS)      | Simple color picker for iPhone      |   [BSD](Attribution/HRColorPickerLicense/LICENSE.txt) |
 | [jQuery](https://jquery.com)      | jQuery is a fast, small, and feature-rich JavaScript library.      |   [MIT](http://jquery.org/license) |
-| [JS Beautifier](https://github.com/einars/js-beautify)      | Makes ugly Javascript pretty      |   [MIT](https://github.com/einars/js-beautify/blob/master/LICENSE) |
+| [JS Beautifier](https://github.com/einars/js-beautify)      | Makes ugly Javascript pretty      |   [MIT](Attribution/jsBeautifierLicense/LICENSE.txt) |
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ The following projects were used in the WordPress-iOS-Editor codebase:
 
 | Component     | Description   | License  |
 | ------------- |:-------------:| -----:|
-| [ZSSRichTextEditor](https://github.com/nnhubbard/ZSSRichTextEditor)      | ZSSRichTextEditor is a rich text WYSIWYG Editor for iOS and was the basis for this project.| [MIT](https://github.com/illyabusigin/CYRTextView/blob/master/LICENSE) |
+| [ZSSRichTextEditor](https://github.com/nnhubbard/ZSSRichTextEditor)      | ZSSRichTextEditor is a rich text WYSIWYG Editor for iOS and was the basis for this project.| [MIT](Attribution/ZSSRichTextEditorLicense/LICENSE.txt) |
 | [CYRTextView](https://github.com/illyabusigin/CYRTextView)      | CYRTextView is a UITextView subclass that implements a variety of features that are relevant to a syntax or code text view. | [MIT](https://github.com/illyabusigin/CYRTextView/blob/master/LICENSE) |
 | [HRColorPicker](https://github.com/hayashi311/Color-Picker-for-iOS)      | Simple color picker for iPhone      |   [BSD](https://github.com/hayashi311/Color-Picker-for-iOS/blob/master/ColorPicker/HRColorPickerView.h) |
 | [jQuery](https://jquery.com)      | jQuery is a fast, small, and feature-rich JavaScript library.      |   [MIT](http://jquery.org/license) |


### PR DESCRIPTION
Resolves some of the concerns raised in #864 .

- Adds the license files from the 3rd party open source projects we're using.
- Updates README.md to point to the local copies of those files.

Please keep in mind the file names are exactly as they were in their original projects so they may look slightly inconsistent.