### PR TITLE
Implement video shortcode self hosted

### DIFF
--- a/Classes/WPEditorFormatbarView.m
+++ b/Classes/WPEditorFormatbarView.m
@@ -45,6 +45,7 @@
 }
 
 - (void)awakeFromNib {
+    [super awakeFromNib];
     [self baseInit];
     return;
 }

--- a/Classes/WPEditorToolbarButton.m
+++ b/Classes/WPEditorToolbarButton.m
@@ -9,7 +9,7 @@ static CGFloat AnimationDurationNormal = 0.3;
 static CGFloat HighlightedAlpha = 0.1;
 static CGFloat NormalAlpha = 1.0;
 
-@interface WPEditorToolbarButton ()
+@interface WPEditorToolbarButton () <CAAnimationDelegate>
 
 @property (nonatomic, weak, readonly) id target;
 @property (nonatomic, assign, readonly) SEL selector;

--- a/Example/EditorDemo/WPViewController.m
+++ b/Example/EditorDemo/WPViewController.m
@@ -35,6 +35,11 @@
 - (void)customizeAppearance
 {
     [super customizeAppearance];
+    // WORKAROUND: Preload the Noto regular font to ensure it is not overridden
+    // by any of the Noto varients.  Size is arbitrary.
+    // See: https://github.com/wordpress-mobile/WordPress-Shared-iOS/issues/79
+    // Remove this when #79 is resolved.
+    [WPFontManager notoRegularFontOfSize:16.0];
     [WPFontManager loadNotoFontFamily];
 
     self.placeholderColor = [WPStyleGuide grey];

--- a/Example/EditorDemo/WPViewController.m
+++ b/Example/EditorDemo/WPViewController.m
@@ -457,7 +457,7 @@
             [self.editorView replaceLocalVideoWithID:videoID
                                       forRemoteVideo:videoURL
                                         remotePoster:posterURL
-                                          videoPress:videoID];
+                                          videoPress:@""];
             [self.videoPressCache setObject:@ {@"source":videoURL, @"poster":posterURL} forKey:videoID];
             [timer invalidate];
         }

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -12,7 +12,7 @@ PODS:
     - CocoaLumberjack (~> 2.2.0)
     - NSObject-SafeExpectations (~> 0.0.2)
     - WordPressCom-Analytics-iOS (~> 0.1.0)
-  - WordPress-iOS-Shared (0.8.0):
+  - WordPress-iOS-Shared (0.8.2):
     - CocoaLumberjack (~> 2.2.0)
   - WordPressCom-Analytics-iOS (0.1.15)
 
@@ -24,13 +24,13 @@ DEPENDENCIES:
 
 EXTERNAL SOURCES:
   WordPress-iOS-Editor:
-    :path: "../"
+    :path: ../
 
 SPEC CHECKSUMS:
   CocoaLumberjack: 17fe8581f84914d5d7e6360f7c70022b173c3ae0
   NSObject-SafeExpectations: 7d7f48df90df4e11da7cfe86b64f45eff7a7f521
   WordPress-iOS-Editor: 69c5d1e83aaa6e5ab6c80e067f1858de8dab4017
-  WordPress-iOS-Shared: 4d073fb8efa96f3c902d1e1ac2557bb720f416d7
+  WordPress-iOS-Shared: 999f5bfcf5744f94ebe9cb7459a138f5990fbf3a
   WordPressCom-Analytics-iOS: e1a7111255e98561c4b5a33ef4baa75a68e0d5d3
 
 PODFILE CHECKSUM: c5af8aa4a9723c2a470c04ad3589d2b2934feb38


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/3911

This is basically a copy of the solution implemented in Android here: https://github.com/wordpress-mobile/WordPress-Android/commit/edded6ff8bbfdd36fdd2160c3c07094226aac80a

How to test:
 - Start the demo app
 - Tap to insert a video
 - Wait for the upload to finish
 - Switch to HTML
 - Check if video was inserted using the [video] shortcode

