### PR TITLE
Fixed #856 Can not save content correctly after "[self stopEditing]" was called if I used "[self setBodyText:]" method.

### DIFF
--- a/Example/EditorDemo/WPViewController.m
+++ b/Example/EditorDemo/WPViewController.m
@@ -30,6 +30,7 @@
                                                                             action:@selector(editTouchedUpInside)];
     self.mediaAdded = [NSMutableDictionary dictionary];
     self.videoPressCache = [[NSCache alloc] init];
+    self.editing = NO;
 }
 
 - (void)customizeAppearance
@@ -60,8 +61,10 @@
 {
     if (self.isEditing) {
         [self stopEditing];
+        self.navigationItem.leftBarButtonItem.title = @"Edit";
     } else {
         [self startEditing];
+        self.navigationItem.leftBarButtonItem.title = @"Save";
     }
 }
 


### PR DESCRIPTION
Fixed this issue by putting the tool into non-edit mode on viewdidload.

I found the ‘Edit’ bar button to be confusing as it’s title doesn’t update based on it’s state. I have fixed that.