### PR TITLE
Remove analytics

### DIFF
--- a/Classes/WPEditorStat.h
+++ b/Classes/WPEditorStat.h
@@ -1,0 +1,15 @@
+typedef NS_ENUM(NSUInteger, WPEditorStat)
+{
+    WPEditorStatTappedBlockquote,
+    WPEditorStatTappedBold,
+    WPEditorStatTappedHTML,
+    WPEditorStatTappedImage,
+    WPEditorStatTappedItalic,
+    WPEditorStatTappedLink,
+    WPEditorStatTappedMore,
+    WPEditorStatTappedOrderedList,
+    WPEditorStatTappedStrikethrough,
+    WPEditorStatTappedUnderline,
+    WPEditorStatTappedUnlink,
+    WPEditorStatTappedUnorderedList
+};

--- a/Classes/WPEditorViewController.h
+++ b/Classes/WPEditorViewController.h
@@ -1,6 +1,8 @@
 #import <UIKit/UIKit.h>
 #import "HRColorPickerViewController.h"
 #import "WPEditorFormatbarView.h"
+#import "WPEditorStat.h"
+
 @class WPEditorField;
 @class WPEditorView;
 @class WPEditorViewController;
@@ -23,6 +25,7 @@ WPEditorViewControllerMode;
 - (void)editorTitleDidChange:(WPEditorViewController *)editorController;
 - (void)editorTextDidChange:(WPEditorViewController *)editorController;
 - (void)editorDidPressMedia:(WPEditorViewController *)editorController;
+- (void)editorTrackStat:(WPEditorStat)stat;
 
 
 /**

--- a/Classes/WPEditorViewController.m
+++ b/Classes/WPEditorViewController.m
@@ -354,6 +354,7 @@
                            animated:YES
                          completion:nil];
     }
+    [self.delegate editorTrackStat:WPEditorStatTappedImage];
 }
 
 #pragma mark - Editor and Misc Methods
@@ -516,6 +517,8 @@
         [self.toolbarView toolBarItemWithTag:kWPEditorViewControllerElementShowSourceBarButton
                                  setSelected:NO];
     }
+
+    [self.delegate editorTrackStat:WPEditorStatTappedHTML];
 }
 
 - (void)removeFormat
@@ -547,18 +550,21 @@
 {
     [self.editorView setBold];
     [self clearToolbar];
+    [self.delegate editorTrackStat:WPEditorStatTappedBold];
 }
 
 - (void)setBlockQuote
 {
     [self.editorView setBlockQuote];
     [self clearToolbar];
+    [self.delegate editorTrackStat:WPEditorStatTappedBlockquote];
 }
 
 - (void)setItalic
 {
     [self.editorView setItalic];
     [self clearToolbar];
+    [self.delegate editorTrackStat:WPEditorStatTappedItalic];
 }
 
 - (void)setSubscript
@@ -570,6 +576,7 @@
 {
 	[self.editorView setUnderline];
     [self clearToolbar];
+    [self.delegate editorTrackStat:WPEditorStatTappedUnderline];
 }
 
 - (void)setSuperscript
@@ -581,18 +588,21 @@
 {
     [self.editorView setStrikethrough];
     [self clearToolbar];
+    [self.delegate editorTrackStat:WPEditorStatTappedStrikethrough];
 }
 
 - (void)setUnorderedList
 {
     [self.editorView setUnorderedList];
     [self clearToolbar];
+    [self.delegate editorTrackStat:WPEditorStatTappedUnorderedList];
 }
 
 - (void)setOrderedList
 {
     [self.editorView setOrderedList];
     [self clearToolbar];
+    [self.delegate editorTrackStat:WPEditorStatTappedOrderedList];
 }
 
 - (void)setHR
@@ -688,6 +698,7 @@
 	} else {
 		[self showInsertLinkDialogWithLink:self.editorView.selectedLinkURL
 									 title:[self.editorView selectedText]];
+        [self.delegate editorTrackStat:WPEditorStatTappedLink];
 	}
 }
 
@@ -811,6 +822,7 @@
 - (void)removeLink
 {
     [self.editorView removeLink];
+    [self.delegate editorTrackStat:WPEditorStatTappedUnlink];
 }
 
 - (void)quickLink

--- a/Classes/WPEditorViewController.m
+++ b/Classes/WPEditorViewController.m
@@ -1,7 +1,6 @@
 #import "WPEditorViewController.h"
 #import <MobileCoreServices/MobileCoreServices.h>
 #import <UIKit/UIKit.h>
-#import <WordPressComAnalytics/WPAnalytics.h>
 
 #import "WPEditorField.h"
 #import "WPEditorToolbarButton.h"
@@ -355,7 +354,6 @@
                            animated:YES
                          completion:nil];
     }
-    [WPAnalytics track:WPAnalyticsStatEditorTappedImage];
 }
 
 #pragma mark - Editor and Misc Methods
@@ -518,8 +516,6 @@
         [self.toolbarView toolBarItemWithTag:kWPEditorViewControllerElementShowSourceBarButton
                                  setSelected:NO];
     }
-    
-    [WPAnalytics track:WPAnalyticsStatEditorTappedHTML];
 }
 
 - (void)removeFormat
@@ -551,21 +547,18 @@
 {
     [self.editorView setBold];
     [self clearToolbar];
-    [WPAnalytics track:WPAnalyticsStatEditorTappedBold];
 }
 
 - (void)setBlockQuote
 {
     [self.editorView setBlockQuote];
     [self clearToolbar];
-    [WPAnalytics track:WPAnalyticsStatEditorTappedBlockquote];
 }
 
 - (void)setItalic
 {
     [self.editorView setItalic];
     [self clearToolbar];
-    [WPAnalytics track:WPAnalyticsStatEditorTappedItalic];
 }
 
 - (void)setSubscript
@@ -577,7 +570,6 @@
 {
 	[self.editorView setUnderline];
     [self clearToolbar];
-    [WPAnalytics track:WPAnalyticsStatEditorTappedUnderline];
 }
 
 - (void)setSuperscript
@@ -589,21 +581,18 @@
 {
     [self.editorView setStrikethrough];
     [self clearToolbar];
-    [WPAnalytics track:WPAnalyticsStatEditorTappedStrikethrough];
 }
 
 - (void)setUnorderedList
 {
     [self.editorView setUnorderedList];
     [self clearToolbar];
-    [WPAnalytics track:WPAnalyticsStatEditorTappedUnorderedList];
 }
 
 - (void)setOrderedList
 {
     [self.editorView setOrderedList];
     [self clearToolbar];
-    [WPAnalytics track:WPAnalyticsStatEditorTappedOrderedList];
 }
 
 - (void)setHR
@@ -699,7 +688,6 @@
 	} else {
 		[self showInsertLinkDialogWithLink:self.editorView.selectedLinkURL
 									 title:[self.editorView selectedText]];
-		[WPAnalytics track:WPAnalyticsStatEditorTappedLink];
 	}
 }
 
@@ -823,7 +811,6 @@
 - (void)removeLink
 {
     [self.editorView removeLink];
-    [WPAnalytics track:WPAnalyticsStatEditorTappedUnlink];
 }
 
 - (void)quickLink

--- a/Classes/WPLegacyEditorViewController.h
+++ b/Classes/WPLegacyEditorViewController.h
@@ -1,4 +1,5 @@
 #import <UIKit/UIKit.h>
+#import "WPEditorStat.h"
 
 @class WPLegacyEditorViewController;
 
@@ -13,6 +14,7 @@
 - (void)editorDidPressSettings:(WPLegacyEditorViewController *)editorController;
 - (void)editorDidPressMedia:(WPLegacyEditorViewController *)editorController;
 - (void)editorDidPressPreview:(WPLegacyEditorViewController *)editorController;
+- (void)editorTrackStat:(WPEditorStat)stat;
 @end
 
 @interface WPLegacyEditorViewController : UIViewController

--- a/Classes/WPLegacyEditorViewController.m
+++ b/Classes/WPLegacyEditorViewController.m
@@ -441,6 +441,34 @@ CGFloat const WPLegacyEPVCTextViewOffset = 10.0;
 
 - (void)formatToolbar:(WPLegacyEditorFormatToolbar *)formatToolbar actionPressed:(WPLegacyEditorFormatAction)formatAction
 {
+    switch (formatAction) {
+        case WPLegacyEditorFormatActionBold:
+            [self.delegate editorTrackStat:WPEditorStatTappedBold];
+            break;
+        case WPLegacyEditorFormatActionItalic:
+            [self.delegate editorTrackStat:WPEditorStatTappedItalic];
+            break;
+        case WPLegacyEditorFormatActionUnderline:
+            [self.delegate editorTrackStat:WPEditorStatTappedUnderline];
+            break;
+        case WPLegacyEditorFormatActionDelete:
+            [self.delegate editorTrackStat:WPEditorStatTappedStrikethrough];
+            break;
+        case WPLegacyEditorFormatActionLink:
+            [self.delegate editorTrackStat:WPEditorStatTappedLink];
+            break;
+        case WPLegacyEditorFormatActionQuote:
+            [self.delegate editorTrackStat:WPEditorStatTappedBlockquote];
+            break;
+        case WPLegacyEditorFormatActionMore:
+            [self.delegate editorTrackStat:WPEditorStatTappedMore];
+            break;
+        case WPLegacyEditorFormatActionMedia:
+            [self.delegate editorTrackStat:WPEditorStatTappedImage];
+            break;
+
+    }
+
     if (formatAction == WPLegacyEditorFormatActionMedia) {
         [self didTouchMediaOptions];
     } else if (formatAction == WPLegacyEditorFormatActionLink) {

--- a/Classes/WPLegacyEditorViewController.m
+++ b/Classes/WPLegacyEditorViewController.m
@@ -1,7 +1,6 @@
 #import "WPLegacyEditorViewController.h"
 #import "WPLegacyEditorFormatToolbar.h"
 #import "WPLegacyEditorFormatAction.h"
-#import <WordPressComAnalytics/WPAnalytics.h>
 
 CGFloat const WPLegacyEPVCStandardOffset = 15.0;
 CGFloat const WPLegacyEPVCTextViewOffset = 10.0;
@@ -442,34 +441,6 @@ CGFloat const WPLegacyEPVCTextViewOffset = 10.0;
 
 - (void)formatToolbar:(WPLegacyEditorFormatToolbar *)formatToolbar actionPressed:(WPLegacyEditorFormatAction)formatAction
 {
-    switch (formatAction) {
-        case WPLegacyEditorFormatActionBold:
-            [WPAnalytics track:WPAnalyticsStatEditorTappedBold];
-            break;
-        case WPLegacyEditorFormatActionItalic:
-            [WPAnalytics track:WPAnalyticsStatEditorTappedItalic];
-            break;
-        case WPLegacyEditorFormatActionUnderline:
-            [WPAnalytics track:WPAnalyticsStatEditorTappedUnderline];
-            break;
-        case WPLegacyEditorFormatActionDelete:
-            [WPAnalytics track:WPAnalyticsStatEditorTappedStrikethrough];
-            break;
-        case WPLegacyEditorFormatActionLink:
-            [WPAnalytics track:WPAnalyticsStatEditorTappedLink];
-            break;
-        case WPLegacyEditorFormatActionQuote:
-            [WPAnalytics track:WPAnalyticsStatEditorTappedBlockquote];
-            break;
-        case WPLegacyEditorFormatActionMore:
-            [WPAnalytics track:WPAnalyticsStatEditorTappedMore];
-            break;
-        case WPLegacyEditorFormatActionMedia:
-            [WPAnalytics track:WPAnalyticsStatEditorTappedImage];
-            break;
-
-    }
-
     if (formatAction == WPLegacyEditorFormatActionMedia) {
         [self didTouchMediaOptions];
     } else if (formatAction == WPLegacyEditorFormatActionLink) {

--- a/Example/Podfile
+++ b/Example/Podfile
@@ -6,7 +6,6 @@ use_frameworks!
 target 'EditorDemo' do
   pod 'WordPress-iOS-Editor', :path => '../'
   pod 'CocoaLumberjack', '~> 3.2.0', :inhibit_warnings => true
-  pod 'WordPressCom-Analytics-iOS', '~>0.1.0', :inhibit_warnings => true
 end
 
 target 'EditorDemoTests' do

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -9,13 +9,10 @@ PODS:
   - WordPress-iOS-Editor (1.9.2):
     - CocoaLumberjack (~> 3.2.0)
     - NSObject-SafeExpectations (~> 0.0.2)
-    - WordPressCom-Analytics-iOS (~> 0.1.0)
-  - WordPressCom-Analytics-iOS (0.1.25)
 
 DEPENDENCIES:
   - CocoaLumberjack (~> 3.2.0)
   - WordPress-iOS-Editor (from `../`)
-  - WordPressCom-Analytics-iOS (~> 0.1.0)
 
 EXTERNAL SOURCES:
   WordPress-iOS-Editor:
@@ -24,9 +21,8 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   CocoaLumberjack: 9b4aed7073d242f29cc2f62068d995faf67f703a
   NSObject-SafeExpectations: 7d7f48df90df4e11da7cfe86b64f45eff7a7f521
-  WordPress-iOS-Editor: e71fa013ac3bf8f448d0ee43421beed3f56500f0
-  WordPressCom-Analytics-iOS: ec36976259d733430ba0fc2f8a51765947d2c7ba
+  WordPress-iOS-Editor: 0965aff97450d0569e15e5bf0b5332b028198257
 
-PODFILE CHECKSUM: 9d7155cbcbabb6020cd8a669ba72e4ae0a4b1e20
+PODFILE CHECKSUM: cb6a541ba5f4aad4728b3cc32bb1c0621d6f7bfa
 
 COCOAPODS: 1.2.1

--- a/WordPress-iOS-Editor.podspec
+++ b/WordPress-iOS-Editor.podspec
@@ -19,7 +19,6 @@ Pod::Spec.new do |s|
   s.exclude_files = 'Classes/exclude'
   s.requires_arc = true
   s.dependency 'CocoaLumberjack', '~> 3.2.0'
-  s.dependency 'WordPressCom-Analytics-iOS', '~>0.1.0'
   s.dependency 'NSObject-SafeExpectations', '~>0.0.2'
   s.header_dir = 'WordPressEditor'
 end


### PR DESCRIPTION
This will help move the analytics pod inside the main repo. We could figure out
some way to inject trackers into the editor, but I think we don't really need
to collect more data on popular toolbar buttons (and if we do, there are better
ways).