### PR TITLE
Added checks for delegate methods and updated doc comments

### DIFF
--- a/Classes/HRColorPickerViewController.h
+++ b/Classes/HRColorPickerViewController.h
@@ -66,8 +66,10 @@ typedef enum {
  */
 - (id)initWithColor:(UIColor*)defaultColor fullColor:(BOOL)fullColor saveStyle:(HCPCSaveStyle)saveStyle;
 
-/** @deprecated use -save: instead of this . */
-- (void)saveColor:(id)sender;
+/**
+ * @deprecated use -save: instead of this.
+ */
+- (void)saveColor:(id)sender __attribute__((deprecated));
 
 - (void)save;
 - (void)save:(id)sender;

--- a/Classes/WPEditorField.h
+++ b/Classes/WPEditorField.h
@@ -18,7 +18,7 @@
  *  @brief      Initializes the field with the specified HTML node id.
  *
  *  @param      nodeId      The id of the html node this object will wrap.  Cannot be nil.
- *  @param      webVieq     The web view to use for all javascript calls.  Cannot be nil.
+ *  @param      webView     The web view to use for all javascript calls.  Cannot be nil.
  *
  *  @returns    The initialized object.
  */
@@ -87,7 +87,7 @@
 /**
  *  @brief      Sets the placeholder color for this field.
  *
- *  @param      placeholderText     The new placeholder color.
+ *  @param      placeholderColor     The new placeholder color.
  */
 - (void)setPlaceholderColor:(UIColor *)placeholderColor;
 

--- a/Classes/WPEditorField.m
+++ b/Classes/WPEditorField.m
@@ -169,7 +169,7 @@ static NSString* const kWPEditorFieldJavascriptTrue = @"true";
     } else {
         
         if (text) {
-            text = [self addSlashes:text];
+            text = [self sanitizeHTML:text];
         } else {
             text = @"";
         }
@@ -187,7 +187,7 @@ static NSString* const kWPEditorFieldJavascriptTrue = @"true";
     } else {
         
         if (html) {
-            html = [self addSlashes:html];
+            html = [self sanitizeHTML:html];
         } else {
             html = @"";
         }
@@ -205,7 +205,7 @@ static NSString* const kWPEditorFieldJavascriptTrue = @"true";
     if (!self.domLoaded) {
         self.preloadedPlaceholderText = placeholderText;
     } else {
-        placeholderText = [self addSlashes:placeholderText];
+        placeholderText = [self sanitizeHTML:placeholderText];
         NSString* javascript = [NSString stringWithFormat:@"%@.setPlaceholderText(\"%@\");", [self wrappedNodeJavascriptAccessor], placeholderText];
         
         [self.webView stringByEvaluatingJavaScriptFromString:javascript];
@@ -232,14 +232,14 @@ static NSString* const kWPEditorFieldJavascriptTrue = @"true";
 #pragma mark - URL & HTML utilities
 
 /**
- *  @brief      Adds slashes to the specified HTML string, to prevent injections when calling JS
+ *  @brief      Adds slashes and removes script tags from the specified HTML string, to prevent injections when calling JS
  *              code.
  *
- *  @param      html        The HTML string to add slashes to.  Cannot be nil.
+ *  @param      html    The HTML string to sanitize.  Cannot be nil.
  *
- *  @returns    The HTML string with the added slashes.
+ *  @returns    The sanitized HTML string.
  */
-- (NSString *)addSlashes:(NSString *)html
+- (NSString *)sanitizeHTML:(NSString *)html
 {
     html = [html stringByReplacingOccurrencesOfString:@"\\" withString:@"\\\\"];
     html = [html stringByReplacingOccurrencesOfString:@"\"" withString:@"\\\""];
@@ -251,6 +251,9 @@ static NSString* const kWPEditorFieldJavascriptTrue = @"true";
     // https://github.com/wordpress-mobile/WordPress-Editor-iOS/issues/830
     html = [html stringByReplacingOccurrencesOfString:@"\u2028"  withString:@"\\u2028"];
     html = [html stringByReplacingOccurrencesOfString:@"\u2029"  withString:@"\\u2029"];
+
+    html = [html stringByReplacingOccurrencesOfString:@"<script>" withString:@"&lt;script&gt;" options:NSCaseInsensitiveSearch range:NSMakeRange(0, [html length])];
+    html = [html stringByReplacingOccurrencesOfString:@"</script>" withString:@"&lt;/script&gt;" options:NSCaseInsensitiveSearch range:NSMakeRange(0, [html length])];
 
     return html;
 }

--- a/Classes/WPEditorView.h
+++ b/Classes/WPEditorView.h
@@ -124,7 +124,7 @@
  * @brief		Received when the user taps on a video in the editor.
  *
  * @param		editorView	The editor view.
- * @param		videoId		The id of image of the image that was tapped.
+ * @param		videoID		The id of image of the image that was tapped.
  * @param		url			The url of the image that was tapped.
  *
  */
@@ -156,7 +156,7 @@ stylesForCurrentSelection:(NSArray*)styles;
  * @brief		Received when a video local url is replaced by the final remote url.
  *
  * @param		editorView	The editor view.
- * @param		videoId		The unique id of the video that had the local url replaced by remote url.
+ * @param		videoID		The unique id of the video that had the local url replaced by remote url.
  *
  */
 - (void)editorView:(WPEditorView*)editorView
@@ -166,7 +166,7 @@ stylesForCurrentSelection:(NSArray*)styles;
  * @brief		Received when an image is pasted into the editor.
  *
  * @param       editorView  The editor view.
- * @param       imageId     The id of image of the image that was pasted.
+ * @param       image The image that was pasted.
  *
  */
 - (void)editorView:(WPEditorView*)editorView

--- a/Classes/WPEditorView.m
+++ b/Classes/WPEditorView.m
@@ -680,7 +680,7 @@ shouldStartLoadWithRequest:(NSURLRequest *)request
 /**
  *	@brief		Handles a video entered fullscreen callback
  *
- *	@param		url		The url with all the callback information.
+ *	@param		aURL		The url with all the callback information.
  */
 - (void)handleVideoFullScreenStartedCallback:(NSURL *)aURL
 {
@@ -717,7 +717,7 @@ shouldStartLoadWithRequest:(NSURLRequest *)request
 /**
  *	@brief		Handles a video ended fullscreen callback.
  *
- *	@param		url		The url with all the callback information.
+ *	@param		aURL		The url with all the callback information.
  */
 - (void)handleVideoFullScreenEndedCallback:(NSURL *)aURL
 {

--- a/Classes/WPEditorViewController.h
+++ b/Classes/WPEditorViewController.h
@@ -31,7 +31,7 @@ WPEditorViewControllerMode;
 /**
  *	@brief		Received when the format bar enabled status has changed.
  *	@param		editorController    The editor view.
- *	@param		enabled             BOOL describing the new state of the format bar
+ *	@param		isEnabled             BOOL describing the new state of the format bar
  */
 - (void)editorFormatBarStatusChanged:(WPEditorViewController *)editorController
                              enabled:(BOOL)isEnabled;
@@ -41,7 +41,7 @@ WPEditorViewControllerMode;
  *  @details    The editor fields will be nil before this method is called.  This is because editor
  *              fields are created as part of the process of loading the HTML.
  *
- *	@param		editorView		The editor view.
+ *	@param		editorViewController		The editor view controller.
  *	@param		field			The new field.
  */
 - (void)editorViewController:(WPEditorViewController*)editorViewController
@@ -50,7 +50,7 @@ WPEditorViewControllerMode;
 /**
  *	@brief		Received when the user taps on a image in the editor.
  *
- *	@param		editorView	The editor view.
+ *	@param		editorViewController	The editor view controller.
  *	@param		imageId		The id of image of the image that was tapped.
  *	@param		url			The url of the image that was tapped.
  *
@@ -62,7 +62,7 @@ WPEditorViewControllerMode;
 /**
  *	@brief		Received when the user taps on a image in the editor.
  *
- *	@param		editorView	The editor view.
+ *	@param		editorViewController	The editor view controller.
  *	@param		imageId		The id of image of the image that was tapped.
  *	@param		url			The url of the image that was tapped.
  *  @param		imageMeta	The parsed meta data about the image.
@@ -75,7 +75,7 @@ WPEditorViewControllerMode;
 /**
  *	@brief		Received when the user taps on a image in the editor.
  *
- *	@param		editorView	The editor view.
+ *	@param		editorViewController	The editor view controller.
  *	@param		videoID		The id of the video that was tapped.
  *	@param		url			The url of the video that was tapped.
  *
@@ -87,7 +87,7 @@ WPEditorViewControllerMode;
 /**
  *	@brief		Received when the local image url is replace by the final image in the editor.
  *
- *	@param		editorView	The editor view.
+ *	@param		editorViewController	The editor view controller.
  *	@param		imageId		The id of image of the image that was tapped.
  */
 - (void)editorViewController:(WPEditorViewController*)editorViewController
@@ -96,7 +96,7 @@ WPEditorViewControllerMode;
 /**
  *	@brief		Received when the local video url is replace by the final video in the editor.
  *
- *	@param		editorView	The editor view.
+ *	@param		editorViewController	The editor view controller.
  *	@param		videoID		The id of video that was tapped.
  */
 - (void)editorViewController:(WPEditorViewController*)editorViewController
@@ -106,7 +106,7 @@ WPEditorViewControllerMode;
  * @brief		Received when an image is pasted into the editor.
  *
  * @param		editorViewController    The editor view controller.
- * @param		imageId                 The id of image of the image that was pasted.
+ * @param		image                   The image that was pasted.
  *
  */
 - (void)editorViewController:(WPEditorViewController*)editorViewController
@@ -115,7 +115,7 @@ WPEditorViewControllerMode;
 /**
  *	@brief		Received when the editor requests information about a videopress video.
  *
- *	@param		editorView	The editor view.
+ *	@param		editorViewController    The editor view controller.
  *	@param		videoID		The id of video that was tapped.
  */
 - (void)editorViewController:(WPEditorViewController *)editorViewController
@@ -124,7 +124,7 @@ WPEditorViewControllerMode;
 /**
  *	@brief		Received when the editor removed an uploading media.
  *
- *	@param		editorView	The editor view.
+ *	@param		editorViewController    The editor view controller.
  *	@param		mediaID		The id of the media that was removed.
  */
 - (void)editorViewController:(WPEditorViewController *)editorViewController

--- a/Classes/WPEditorViewController.m
+++ b/Classes/WPEditorViewController.m
@@ -354,7 +354,9 @@
                            animated:YES
                          completion:nil];
     }
-    [self.delegate editorTrackStat:WPEditorStatTappedImage];
+    if ([self.delegate respondsToSelector: @selector(editorTrackStat:)]) {
+        [self.delegate editorTrackStat:WPEditorStatTappedImage];
+    }
 }
 
 #pragma mark - Editor and Misc Methods
@@ -518,7 +520,9 @@
                                  setSelected:NO];
     }
 
-    [self.delegate editorTrackStat:WPEditorStatTappedHTML];
+    if ([self.delegate respondsToSelector: @selector(editorTrackStat:)]) {
+        [self.delegate editorTrackStat:WPEditorStatTappedHTML];
+    }
 }
 
 - (void)removeFormat
@@ -550,21 +554,27 @@
 {
     [self.editorView setBold];
     [self clearToolbar];
-    [self.delegate editorTrackStat:WPEditorStatTappedBold];
+    if ([self.delegate respondsToSelector: @selector(editorTrackStat:)]) {
+        [self.delegate editorTrackStat:WPEditorStatTappedBold];
+    }
 }
 
 - (void)setBlockQuote
 {
     [self.editorView setBlockQuote];
     [self clearToolbar];
-    [self.delegate editorTrackStat:WPEditorStatTappedBlockquote];
+    if ([self.delegate respondsToSelector: @selector(editorTrackStat:)]) {
+        [self.delegate editorTrackStat:WPEditorStatTappedBlockquote];
+    }
 }
 
 - (void)setItalic
 {
     [self.editorView setItalic];
     [self clearToolbar];
-    [self.delegate editorTrackStat:WPEditorStatTappedItalic];
+    if ([self.delegate respondsToSelector: @selector(editorTrackStat:)]) {
+        [self.delegate editorTrackStat:WPEditorStatTappedItalic];
+    }
 }
 
 - (void)setSubscript
@@ -576,7 +586,9 @@
 {
 	[self.editorView setUnderline];
     [self clearToolbar];
-    [self.delegate editorTrackStat:WPEditorStatTappedUnderline];
+    if ([self.delegate respondsToSelector: @selector(editorTrackStat:)]) {
+        [self.delegate editorTrackStat:WPEditorStatTappedUnderline];
+    }
 }
 
 - (void)setSuperscript
@@ -588,21 +600,27 @@
 {
     [self.editorView setStrikethrough];
     [self clearToolbar];
-    [self.delegate editorTrackStat:WPEditorStatTappedStrikethrough];
+    if ([self.delegate respondsToSelector: @selector(editorTrackStat:)]) {
+        [self.delegate editorTrackStat:WPEditorStatTappedStrikethrough];
+    }
 }
 
 - (void)setUnorderedList
 {
     [self.editorView setUnorderedList];
     [self clearToolbar];
-    [self.delegate editorTrackStat:WPEditorStatTappedUnorderedList];
+    if ([self.delegate respondsToSelector: @selector(editorTrackStat:)]) {
+        [self.delegate editorTrackStat:WPEditorStatTappedUnorderedList];
+    }
 }
 
 - (void)setOrderedList
 {
     [self.editorView setOrderedList];
     [self clearToolbar];
-    [self.delegate editorTrackStat:WPEditorStatTappedOrderedList];
+    if ([self.delegate respondsToSelector: @selector(editorTrackStat:)]) {
+        [self.delegate editorTrackStat:WPEditorStatTappedOrderedList];
+    }
 }
 
 - (void)setHR
@@ -698,7 +716,9 @@
 	} else {
 		[self showInsertLinkDialogWithLink:self.editorView.selectedLinkURL
 									 title:[self.editorView selectedText]];
-        [self.delegate editorTrackStat:WPEditorStatTappedLink];
+        if ([self.delegate respondsToSelector: @selector(editorTrackStat:)]) {
+            [self.delegate editorTrackStat:WPEditorStatTappedLink];
+        }
 	}
 }
 
@@ -822,7 +842,9 @@
 - (void)removeLink
 {
     [self.editorView removeLink];
-    [self.delegate editorTrackStat:WPEditorStatTappedUnlink];
+    if ([self.delegate respondsToSelector: @selector(editorTrackStat:)]) {
+        [self.delegate editorTrackStat:WPEditorStatTappedUnlink];
+    }
 }
 
 - (void)quickLink

--- a/Classes/WPEditorViewController.m
+++ b/Classes/WPEditorViewController.m
@@ -866,8 +866,6 @@
 
 /**
  *	@brief		Returns an URL from the general pasteboard.
- *
- *	@param		The URL or nil if no valid URL is found.
  */
 - (NSURL*)urlFromPasteboard
 {

--- a/Classes/WPLegacyEditorViewController.m
+++ b/Classes/WPLegacyEditorViewController.m
@@ -443,28 +443,44 @@ CGFloat const WPLegacyEPVCTextViewOffset = 10.0;
 {
     switch (formatAction) {
         case WPLegacyEditorFormatActionBold:
-            [self.delegate editorTrackStat:WPEditorStatTappedBold];
+            if ([self.delegate respondsToSelector: @selector(editorTrackStat:)]) {
+                [self.delegate editorTrackStat:WPEditorStatTappedBold];
+            }
             break;
         case WPLegacyEditorFormatActionItalic:
-            [self.delegate editorTrackStat:WPEditorStatTappedItalic];
+            if ([self.delegate respondsToSelector: @selector(editorTrackStat:)]) {
+                [self.delegate editorTrackStat:WPEditorStatTappedItalic];
+            }
             break;
         case WPLegacyEditorFormatActionUnderline:
-            [self.delegate editorTrackStat:WPEditorStatTappedUnderline];
+            if ([self.delegate respondsToSelector: @selector(editorTrackStat:)]) {
+                [self.delegate editorTrackStat:WPEditorStatTappedUnderline];
+            }
             break;
         case WPLegacyEditorFormatActionDelete:
-            [self.delegate editorTrackStat:WPEditorStatTappedStrikethrough];
+            if ([self.delegate respondsToSelector: @selector(editorTrackStat:)]) {
+                [self.delegate editorTrackStat:WPEditorStatTappedStrikethrough];
+            }
             break;
         case WPLegacyEditorFormatActionLink:
-            [self.delegate editorTrackStat:WPEditorStatTappedLink];
+            if ([self.delegate respondsToSelector: @selector(editorTrackStat:)]) {
+                [self.delegate editorTrackStat:WPEditorStatTappedLink];
+            }
             break;
         case WPLegacyEditorFormatActionQuote:
-            [self.delegate editorTrackStat:WPEditorStatTappedBlockquote];
+            if ([self.delegate respondsToSelector: @selector(editorTrackStat:)]) {
+                [self.delegate editorTrackStat:WPEditorStatTappedBlockquote];
+            }
             break;
         case WPLegacyEditorFormatActionMore:
-            [self.delegate editorTrackStat:WPEditorStatTappedMore];
+            if ([self.delegate respondsToSelector: @selector(editorTrackStat:)]) {
+                [self.delegate editorTrackStat:WPEditorStatTappedMore];
+            }
             break;
         case WPLegacyEditorFormatActionMedia:
-            [self.delegate editorTrackStat:WPEditorStatTappedImage];
+            if ([self.delegate respondsToSelector: @selector(editorTrackStat:)]) {
+                [self.delegate editorTrackStat:WPEditorStatTappedImage];
+            }
             break;
 
     }

--- a/Example/EditorDemo/WPViewController.m
+++ b/Example/EditorDemo/WPViewController.m
@@ -118,6 +118,10 @@
     DDLogInfo(@"Editor field created: %@", field.nodeId);
 }
 
+- (void)editorTrackStat:(WPEditorStat)stat {
+    DDLogInfo(@"Editor stat tracked: %lu", (unsigned long)stat);
+}
+
 - (void)editorViewController:(WPEditorViewController*)editorViewController
                  imageTapped:(NSString *)imageId
                          url:(NSURL *)url


### PR DESCRIPTION
This PR:
* Updates invalid doc comments
* Adds checks for an optional delegate method to avoid crashes if not implemented: `@selector(editorTrackStat:)`
* Fixes an issue with `addSlashes:` method on `WPEditorField.m` and renames it to `sanitizeHTML:`

To test:
1. Build and run the Editor demo. Verify everything works and doc warnings are gone.
2. Build and run WPiOS on [this branch](https://github.com/wordpress-mobile/WordPress-iOS/tree/issue/update-hybrid-editor-pod). Verify everything works.

@elibud would you mind reviewing?