### PR TITLE
Formatbar: Add method to return toolbar item matching a given tag

### DIFF
--- a/Classes/WPEditorFormatbarView.h
+++ b/Classes/WPEditorFormatbarView.h
@@ -140,6 +140,14 @@ typedef enum
 #pragma mark - Toolbar items
 
 /**
+ *  @brief      Returns a toolbar item (if any) matching the specified tag.
+ *
+ *  @param      tag     WPEditorViewControllerElementTag of the item to return.
+ *  @return     A toolbar item with the specified tag.
+ */
+- (UIBarButtonItem *)toolBarItemWithTag:(WPEditorViewControllerElementTag)tag;
+
+/**
  *  @brief      Makes a toolbar item visible or hidden
  *
  *  @param      tag     WPEditorViewControllerElementTag of the item to alter.

--- a/Classes/WPEditorFormatbarView.m
+++ b/Classes/WPEditorFormatbarView.m
@@ -189,6 +189,27 @@
 
 #pragma mark - Toolbar items
 
+- (UIBarButtonItem *)toolBarItemWithTag:(WPEditorViewControllerElementTag)tag
+{
+    // Find whichever toolbar is currently installed in the view hierarchy.
+    UIToolbar *toolbar;
+    if (self.leftToolbar.window) {
+        toolbar = self.leftToolbar;
+    } else if (self.regularToolbar.window) {
+        toolbar = self.regularToolbar;
+    }
+
+    if (toolbar) {
+        for (ZSSBarButtonItem *item in toolbar.items) {
+            if (item.tag == tag) {
+                return item;
+            }
+        }
+    }
+
+    return nil;
+}
+
 - (void)toolBarItemWithTag:(WPEditorViewControllerElementTag)tag setVisible:(BOOL)visible
 {
     for (ZSSBarButtonItem *item in self.leftToolbar.items) {


### PR DESCRIPTION
This PR adds a method to `WPEditorFormatbarView`, `toolBarItemWithTag:` to return a toolbar button matching the specified tag. This is needed so we can display a popover from the media button in this PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/7774

Needs review: @bummytime 