### PR TITLE
More fix for layouts

### DIFF
--- a/Assets/WPEditorFormatbarView.xib
+++ b/Assets/WPEditorFormatbarView.xib
@@ -49,7 +49,7 @@
                     </variation>
                 </toolbar>
                 <toolbar opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="n1r-fs-i80">
-                    <rect key="frame" x="0.0" y="-5" width="482" height="49"/>
+                    <rect key="frame" x="0.0" y="0.0" width="482" height="44"/>
                     <items>
                         <barButtonItem style="plain" systemItem="flexibleSpace" id="dUc-fD-xmY"/>
                         <barButtonItem title="Img" width="44" style="plain" id="IvH-tE-Dmv" customClass="ZSSBarButtonItem"/>
@@ -71,7 +71,7 @@
                     </items>
                 </toolbar>
                 <view contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" translatesAutoresizingMaskIntoConstraints="NO" id="5oj-N8-CBI">
-                    <rect key="frame" x="0.0" y="-5" width="482" height="1"/>
+                    <rect key="frame" x="0.0" y="0.0" width="482" height="1"/>
                     <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="1" id="DQc-We-xJ8"/>

--- a/Assets/WPEditorFormatbarView.xib
+++ b/Assets/WPEditorFormatbarView.xib
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13196" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
-    <device id="retina5_5" orientation="landscape">
+    <device id="retina5_9" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
@@ -49,7 +49,7 @@
                     </variation>
                 </toolbar>
                 <toolbar opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="n1r-fs-i80">
-                    <rect key="frame" x="0.0" y="0.0" width="482" height="44"/>
+                    <rect key="frame" x="0.0" y="-5" width="482" height="49"/>
                     <items>
                         <barButtonItem style="plain" systemItem="flexibleSpace" id="dUc-fD-xmY"/>
                         <barButtonItem title="Img" width="44" style="plain" id="IvH-tE-Dmv" customClass="ZSSBarButtonItem"/>
@@ -71,7 +71,7 @@
                     </items>
                 </toolbar>
                 <view contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" translatesAutoresizingMaskIntoConstraints="NO" id="5oj-N8-CBI">
-                    <rect key="frame" x="0.0" y="0.0" width="482" height="1"/>
+                    <rect key="frame" x="0.0" y="-5" width="482" height="1"/>
                     <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="1" id="DQc-We-xJ8"/>
@@ -119,9 +119,6 @@
                     <exclude reference="5oj-N8-CBI"/>
                 </mask>
                 <mask key="constraints">
-                    <exclude reference="KLa-wT-1Gc"/>
-                    <exclude reference="Yfe-DH-K5f"/>
-                    <exclude reference="kVg-01-4Kx"/>
                     <exclude reference="3Qa-Uv-8nO"/>
                     <exclude reference="9Gh-oq-DQO"/>
                     <exclude reference="K0a-ZY-Z3h"/>
@@ -131,6 +128,9 @@
                     <exclude reference="3Cf-0J-TmW"/>
                     <exclude reference="4b9-4h-eWO"/>
                     <exclude reference="NZc-BN-ZZf"/>
+                    <exclude reference="KLa-wT-1Gc"/>
+                    <exclude reference="Yfe-DH-K5f"/>
+                    <exclude reference="kVg-01-4Kx"/>
                 </mask>
             </variation>
             <variation key="widthClass=compact">
@@ -139,12 +139,12 @@
                     <include reference="5oj-N8-CBI"/>
                 </mask>
                 <mask key="constraints">
-                    <include reference="KLa-wT-1Gc"/>
-                    <include reference="Yfe-DH-K5f"/>
-                    <include reference="kVg-01-4Kx"/>
                     <include reference="3Qa-Uv-8nO"/>
                     <include reference="MY8-Yb-Zho"/>
                     <include reference="hKN-cF-AOT"/>
+                    <include reference="KLa-wT-1Gc"/>
+                    <include reference="Yfe-DH-K5f"/>
+                    <include reference="kVg-01-4Kx"/>
                 </mask>
             </variation>
             <variation key="widthClass=regular">

--- a/Classes/WPEditorFormatbarView.h
+++ b/Classes/WPEditorFormatbarView.h
@@ -3,6 +3,8 @@
 @class WPEditorFormatbarView;
 @class ZSSBarButtonItem;
 
+extern const CGFloat WPEditorFormatbarViewToolbarHeight;
+
 typedef enum
 {
     kWPEditorViewControllerElementTagUnknown = -1,

--- a/Classes/WPEditorFormatbarView.m
+++ b/Classes/WPEditorFormatbarView.m
@@ -4,6 +4,8 @@
 #import "WPEditorToolbarButton.h"
 #import "ZSSBarButtonItem.h"
 
+const CGFloat WPEditorFormatbarViewToolbarHeight = 44;
+
 @interface WPEditorFormatbarView ()
 
 @property (unsafe_unretained, nonatomic) IBOutlet UIToolbar *leftToolbar;

--- a/Classes/WPEditorView.m
+++ b/Classes/WPEditorView.m
@@ -28,7 +28,6 @@ static const CGFloat UITextFieldFieldHeight = 55.0;
 static const CGFloat SourceTitleTextFieldYOffset = 4.0;
 static const CGFloat HTMLViewTopInset = 15.0;
 static const CGFloat HTMLViewLeftRightInset = 15.0;
-static const CGFloat ToolbarHeight = 44;
 
 static NSString* const WPEditorViewWebViewContentSizeKey = @"contentSize";
 
@@ -134,8 +133,6 @@ static NSString* const WPEditorViewWebViewContentSizeKey = @"contentSize";
     CGFloat top = HTMLViewTopInset + insets.top;
     CGFloat bottom = 0;
     self.sourceView.textContainerInset = UIEdgeInsetsMake(top, left, bottom, right);
-
-    [self refreshInputViewsFrames];
 }
 
 #pragma mark - Init helpers
@@ -351,22 +348,6 @@ static NSString* const WPEditorViewWebViewContentSizeKey = @"contentSize";
     self.webView.scrollView.scrollIndicatorInsets = insets;
     self.sourceView.contentInset = insets;
     self.sourceView.scrollIndicatorInsets = insets;
-
-    [self refreshInputViewsFrames];
-}
-
-- (void)refreshInputViewsFrames {
-
-    UIEdgeInsets insets = UIEdgeInsetsZero;
-    if (@available(iOS 11, *)) {
-        insets = self.sourceView.inputAccessoryView.safeAreaInsets;
-    }
-
-    CGRect newFrame = CGRectMake(0, 0, self.bounds.size.width, ToolbarHeight + insets.bottom);
-    self.sourceView.inputAccessoryView.frame = newFrame;
-    self.sourceViewTitleField.inputAccessoryView.frame = newFrame;
-    self.titleField.inputAccessoryView.frame = newFrame;
-    self.contentField.inputAccessoryView.frame = newFrame;
 }
 
 - (void)keyboardWillHide:(NSNotification *)notification

--- a/Classes/WPEditorViewController.m
+++ b/Classes/WPEditorViewController.m
@@ -17,7 +17,11 @@
 - (instancetype)initWithToolbar:(WPEditorFormatbarView *)toolbar {
     self = [super initWithFrame:CGRectMake(0, 0, self.frame.size.width, WPEditorFormatbarViewToolbarHeight)];
     if (self) {
-        self.toolbar = toolbar;
+        _toolbar = toolbar;
+        self.autoresizingMask = UIViewAutoresizingFlexibleHeight;
+        self.backgroundColor = _toolbar.backgroundColor;
+        [self addSubview:toolbar];
+        self.translatesAutoresizingMaskIntoConstraints = YES;
     }
     return self;
 }
@@ -979,18 +983,7 @@
 - (UIView *)wrapperViewForInputView {
     static CustomWrapperViewForInputView *wrapperForInputView;
     if (wrapperForInputView == nil) {
-        UIEdgeInsets insets = UIEdgeInsetsZero;
-        if (@available(iOS 11.0, *)) {
-            insets = self.view.safeAreaInsets;
-        } else {
-            // Fallback on earlier versions
-        }
         wrapperForInputView = [[CustomWrapperViewForInputView alloc] initWithToolbar:self.toolbarView];
-        wrapperForInputView.autoresizingMask = UIViewAutoresizingFlexibleHeight;
-        wrapperForInputView.backgroundColor = [UIColor orangeColor];
-        UIView *toolbar = self.toolbarView;
-        [wrapperForInputView addSubview:toolbar];
-        wrapperForInputView.translatesAutoresizingMaskIntoConstraints = YES;
     };
     return wrapperForInputView;
 }

--- a/Classes/WPEditorViewController.m
+++ b/Classes/WPEditorViewController.m
@@ -27,6 +27,7 @@
 }
 
 - (void)safeAreaInsetsDidChange {
+    [super safeAreaInsetsDidChange];
     [self invalidateIntrinsicContentSize];
 }
 
@@ -38,7 +39,7 @@
     UIEdgeInsets insets = UIEdgeInsetsZero;
     if(@available(iOS 11, *)){
         insets = self.safeAreaInsets;
-    }    
+    }
     return CGSizeMake(UIViewNoIntrinsicMetric, WPEditorFormatbarViewToolbarHeight + insets.bottom);;
 }
 

--- a/Classes/WPEditorViewController.m
+++ b/Classes/WPEditorViewController.m
@@ -24,7 +24,9 @@
 
 - (void)safeAreaInsetsDidChange {
     UIEdgeInsets insets = UIEdgeInsetsZero;
-    insets = self.safeAreaInsets;
+    if(@available(iOS 11, *)){
+        insets = self.safeAreaInsets;
+    }
     CGRect frame = CGRectMake(0, 0, self.frame.size.width, WPEditorFormatbarViewToolbarHeight + insets.bottom);
     self.frame = frame;
 }
@@ -199,7 +201,7 @@
 - (void)willTransitionToTraitCollection:(UITraitCollection *)newCollection withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator
 {
     [super willTransitionToTraitCollection:newCollection withTransitionCoordinator:coordinator];
-    [self.toolbarView setNeedsLayout];
+    [[self wrapForInputView] setNeedsLayout];
 }
 
 #pragma mark - Keyboard shortcuts

--- a/Classes/WPEditorViewController.m
+++ b/Classes/WPEditorViewController.m
@@ -8,11 +8,11 @@
 #import "WPImageMeta.h"
 #import "ZSSBarButtonItem.h"
 
-@interface CustomWrapperViewForInputView: UIView
+@interface WrapperViewForInputView: UIView
     @property (nonatomic, strong) WPEditorFormatbarView *toolbar;
 @end
 
-@implementation CustomWrapperViewForInputView
+@implementation WrapperViewForInputView
 
 - (instancetype)initWithToolbar:(WPEditorFormatbarView *)toolbar {
     self = [super initWithFrame:CGRectMake(0, 0, self.frame.size.width, WPEditorFormatbarViewToolbarHeight)];
@@ -38,9 +38,8 @@
     UIEdgeInsets insets = UIEdgeInsetsZero;
     if(@available(iOS 11, *)){
         insets = self.safeAreaInsets;
-    }
-    CGSize size = CGSizeMake(UIViewNoIntrinsicMetric, WPEditorFormatbarViewToolbarHeight + insets.bottom);
-    return size;
+    }    
+    return CGSizeMake(UIViewNoIntrinsicMetric, WPEditorFormatbarViewToolbarHeight + insets.bottom);;
 }
 
 @end
@@ -69,6 +68,8 @@
 #pragma mark - Properties: Toolbar
 
 @property (nonatomic, strong, readwrite) WPEditorFormatbarView* toolbarView;
+
+@property (nonatomic, strong, readwrite) WrapperViewForInputView* wrapperViewForInputView;
 
 @end
 
@@ -309,8 +310,8 @@
         self.editorView.autoresizesSubviews = YES;
         self.editorView.autoresizingMask = mask;
         self.editorView.backgroundColor = [UIColor whiteColor];
-        self.editorView.sourceView.inputAccessoryView = [self wrapperViewForInputView];
-        self.editorView.sourceViewTitleField.inputAccessoryView = [self wrapperViewForInputView];
+        self.editorView.sourceView.inputAccessoryView = self.wrapperViewForInputView;
+        self.editorView.sourceViewTitleField.inputAccessoryView = self.wrapperViewForInputView;
         
         // Default placeholder text
         self.titlePlaceholderText = NSLocalizedString(@"Post title",  @"Placeholder for the post title.");
@@ -981,11 +982,10 @@
 }
 
 - (UIView *)wrapperViewForInputView {
-    static CustomWrapperViewForInputView *wrapperForInputView;
-    if (wrapperForInputView == nil) {
-        wrapperForInputView = [[CustomWrapperViewForInputView alloc] initWithToolbar:self.toolbarView];
+    if (_wrapperViewForInputView == nil) {
+        _wrapperViewForInputView = [[WrapperViewForInputView alloc] initWithToolbar:self.toolbarView];
     };
-    return wrapperForInputView;
+    return _wrapperViewForInputView;
 }
 - (void)editorViewDidFinishLoadingDOM:(WPEditorView*)editorView
 {
@@ -1008,7 +1008,7 @@
       fieldCreated:(WPEditorField*)field
 {
     if (field == self.editorView.titleField) {
-        field.inputAccessoryView = [self wrapperViewForInputView];
+        field.inputAccessoryView = self.wrapperViewForInputView;
         
         [field setRightToLeftTextEnabled:[self isCurrentLanguageDirectionRTL]];
         [field setMultiline:NO];
@@ -1017,7 +1017,7 @@
         self.editorView.sourceViewTitleField.attributedPlaceholder = [[NSAttributedString alloc] initWithString:self.titlePlaceholderText
                                                                                                      attributes:@{NSForegroundColorAttributeName: self.placeholderColor}];
     } else if (field == self.editorView.contentField) {
-        field.inputAccessoryView = [self wrapperViewForInputView];
+        field.inputAccessoryView = self.wrapperViewForInputView;
         
         [field setRightToLeftTextEnabled:[self isCurrentLanguageDirectionRTL]];
         [field setMultiline:YES];

--- a/Classes/WPEditorViewController.m
+++ b/Classes/WPEditorViewController.m
@@ -23,16 +23,20 @@
 }
 
 - (void)safeAreaInsetsDidChange {
-    UIEdgeInsets insets = UIEdgeInsetsZero;
-    if(@available(iOS 11, *)){
-        insets = self.safeAreaInsets;
-    }
-    CGRect frame = CGRectMake(0, 0, self.frame.size.width, WPEditorFormatbarViewToolbarHeight + insets.bottom);
-    self.frame = frame;
+    [self invalidateIntrinsicContentSize];
 }
 
 - (void)layoutSubviews {
     self.toolbar.frame = CGRectMake(0, 0, self.frame.size.width, self.frame.size.height);
+}
+
+- (CGSize)intrinsicContentSize {
+    UIEdgeInsets insets = UIEdgeInsetsZero;
+    if(@available(iOS 11, *)){
+        insets = self.safeAreaInsets;
+    }
+    CGSize size = CGSizeMake(UIViewNoIntrinsicMetric, WPEditorFormatbarViewToolbarHeight + insets.bottom);
+    return size;
 }
 
 @end
@@ -172,8 +176,7 @@
         // Note: Very important this is set here otherwise the post will not initially
         // load properly in the editor. Please be careful if you make a change here and
         // test the editor within WPiOS!
-        self.isFirstSetupComplete = YES;
-        [[self wrapForInputView] setNeedsLayout];
+        self.isFirstSetupComplete = YES;        
     }
 }
 
@@ -201,7 +204,7 @@
 - (void)willTransitionToTraitCollection:(UITraitCollection *)newCollection withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator
 {
     [super willTransitionToTraitCollection:newCollection withTransitionCoordinator:coordinator];
-    [[self wrapForInputView] setNeedsLayout];
+    [[self wrapperViewForInputView] setNeedsLayout];
 }
 
 #pragma mark - Keyboard shortcuts
@@ -302,8 +305,8 @@
         self.editorView.autoresizesSubviews = YES;
         self.editorView.autoresizingMask = mask;
         self.editorView.backgroundColor = [UIColor whiteColor];
-        self.editorView.sourceView.inputAccessoryView = [self wrapForInputView];
-        self.editorView.sourceViewTitleField.inputAccessoryView = [self wrapForInputView];
+        self.editorView.sourceView.inputAccessoryView = [self wrapperViewForInputView];
+        self.editorView.sourceViewTitleField.inputAccessoryView = [self wrapperViewForInputView];
         
         // Default placeholder text
         self.titlePlaceholderText = NSLocalizedString(@"Post title",  @"Placeholder for the post title.");
@@ -973,7 +976,7 @@
     }
 }
 
-- (UIView *)wrapForInputView {
+- (UIView *)wrapperViewForInputView {
     static CustomWrapperViewForInputView *wrapperForInputView;
     if (wrapperForInputView == nil) {
         UIEdgeInsets insets = UIEdgeInsetsZero;
@@ -1012,7 +1015,7 @@
       fieldCreated:(WPEditorField*)field
 {
     if (field == self.editorView.titleField) {
-        field.inputAccessoryView = [self wrapForInputView];
+        field.inputAccessoryView = [self wrapperViewForInputView];
         
         [field setRightToLeftTextEnabled:[self isCurrentLanguageDirectionRTL]];
         [field setMultiline:NO];
@@ -1021,7 +1024,7 @@
         self.editorView.sourceViewTitleField.attributedPlaceholder = [[NSAttributedString alloc] initWithString:self.titlePlaceholderText
                                                                                                      attributes:@{NSForegroundColorAttributeName: self.placeholderColor}];
     } else if (field == self.editorView.contentField) {
-        field.inputAccessoryView = [self wrapForInputView];
+        field.inputAccessoryView = [self wrapperViewForInputView];
         
         [field setRightToLeftTextEnabled:[self isCurrentLanguageDirectionRTL]];
         [field setMultiline:YES];

--- a/Classes/WPLegacyEditorViewController.m
+++ b/Classes/WPLegacyEditorViewController.m
@@ -7,27 +7,34 @@ CGFloat const WPLegacyEPVCTextViewOffset = 10.0;
 CGFloat const WPLegacyEPVCToolbarHeight = 44.0;
 
 @interface WPLegacyWrapperViewForInputView: UIView
-    @property (nonatomic, strong) UIToolbar *toolbar;
+    @property (nonatomic, strong) WPLegacyEditorFormatToolbar *toolbar;
 @end
 
 @implementation WPLegacyWrapperViewForInputView
 
-- (instancetype)initWithToolbar:(UIToolbar *)toolbar {
-    self = [super initWithFrame:CGRectMake(0, 0, self.frame.size.width, toolbar.frame.size.height)];
+- (instancetype)initWithToolbar:(WPLegacyEditorFormatToolbar *)toolbar {
+    self = [super initWithFrame:CGRectMake(0, 0, self.frame.size.width, WPLegacyEPVCToolbarHeight)];
     if (self) {
         _toolbar = toolbar;
         self.autoresizingMask = UIViewAutoresizingFlexibleHeight;
-        self.backgroundColor = [[WPLegacyEditorFormatToolbar appearance] backgroundColor];
+        self.backgroundColor = toolbar.backgroundColor ? toolbar.backgroundColor : [[WPLegacyEditorFormatToolbar appearance] backgroundColor];
         [self addSubview:toolbar];
         [[toolbar.topAnchor constraintEqualToAnchor:self.topAnchor] setActive:YES];
         [[toolbar.leftAnchor constraintEqualToAnchor:self.leftAnchor] setActive:YES];
         [[toolbar.rightAnchor constraintEqualToAnchor:self.rightAnchor] setActive:YES];
+        toolbar.translatesAutoresizingMaskIntoConstraints = NO;
         self.translatesAutoresizingMaskIntoConstraints = NO;
     }
     return self;
 }
 
+- (void)layoutSubviews {
+    [super layoutSubviews];
+    self.toolbar.frame = CGRectMake(self.toolbar.frame.origin.x, 0, self.toolbar.frame.size.width, WPLegacyEPVCToolbarHeight);
+}
+
 - (void)safeAreaInsetsDidChange {
+    [super safeAreaInsetsDidChange];
     [self invalidateIntrinsicContentSize];
 }
 
@@ -36,7 +43,7 @@ CGFloat const WPLegacyEPVCToolbarHeight = 44.0;
     if(@available(iOS 11, *)){
         insets = self.safeAreaInsets;
     }    
-    return CGSizeMake(UIViewNoIntrinsicMetric, self.toolbar.frame.size.height + insets.bottom);
+    return CGSizeMake(UIViewNoIntrinsicMetric, WPLegacyEPVCToolbarHeight + insets.bottom);
 }
 
 @end

--- a/Example/EditorDemo.xcodeproj/xcshareddata/xcschemes/EditorDemo.xcscheme
+++ b/Example/EditorDemo.xcodeproj/xcshareddata/xcschemes/EditorDemo.xcscheme
@@ -61,6 +61,7 @@
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
+      stopOnEveryMainThreadCheckerIssue = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
       <BuildableProductRunnable


### PR DESCRIPTION
Adds extra fixes for layouts because of rotations to landscape on iPhoneX.

How to test:
 - On the iPhoneX, iPhone normal and iPad check if toolbar of editor shows correctly.
 - Try on iOS 11 and iOS10.

There is an integration branch on WP-iOS named: issue/update_hybrid_editor_to_1.9.6 to test directly on the main app.
